### PR TITLE
fix(continue): use Pi TUI keyboard matching

### DIFF
--- a/extensions/continue/src/key-input.ts
+++ b/extensions/continue/src/key-input.ts
@@ -1,0 +1,107 @@
+import { decodeKittyPrintable, Key, matchesKey, parseKey, StdinBuffer, type KeyId } from "@earendil-works/pi-tui";
+
+type TextKey = "up" | "down" | "page-up" | "page-down" | "home" | "end" | "close";
+type PaletteKey = "up" | "down" | "left" | "right" | "enter" | "escape" | "ctrl-c" | "ctrl-u" | "backspace" | "delete" | "home" | "end";
+
+const TEXT_KEY_IDS: Record<TextKey, readonly KeyId[]> = {
+	up: [Key.up, "k"],
+	down: [Key.down, "j"],
+	"page-up": [Key.pageUp],
+	"page-down": [Key.pageDown],
+	home: [Key.home],
+	end: [Key.end],
+	close: [Key.enter, Key.return, Key.escape, Key.esc, Key.ctrl("c"), "q"],
+};
+
+const TEXT_KEY_ALIASES: Partial<Record<TextKey, readonly string[]>> = {
+	"page-up": ["pageup", "page-up"],
+	"page-down": ["pagedown", "page-down"],
+};
+
+const PALETTE_KEY_IDS: Record<PaletteKey, readonly KeyId[]> = {
+	up: [Key.up],
+	down: [Key.down],
+	left: [Key.left],
+	right: [Key.right],
+	enter: [Key.enter, Key.return],
+	escape: [Key.escape, Key.esc],
+	"ctrl-c": [Key.ctrl("c")],
+	"ctrl-u": [Key.ctrl("u")],
+	backspace: [Key.backspace],
+	delete: [Key.delete],
+	home: [Key.home],
+	end: [Key.end],
+};
+
+function splitInput(data: string): string[] {
+	const buffer = new StdinBuffer({ timeout: 1_000 });
+	const events: string[] = [];
+	buffer.on("data", (event) => events.push(event));
+	buffer.process(data);
+	events.push(...buffer.flush());
+	buffer.destroy();
+	return events.length > 0 ? events : [data];
+}
+
+function matchesKeyId(data: string, keyIds: readonly KeyId[], aliases: readonly string[] = []): boolean {
+	return keyIds.includes(data as KeyId) || aliases.includes(data) || keyIds.some((keyId) => matchesKey(data, keyId));
+}
+
+export function keyRepeat(data: string, key: TextKey): number {
+	const keyIds = TEXT_KEY_IDS[key];
+	const aliases = TEXT_KEY_ALIASES[key] ?? [];
+	if (matchesKeyId(data, keyIds, aliases)) return 1;
+	let count = 0;
+	for (const event of splitInput(data)) {
+		if (!matchesKeyId(event, keyIds, aliases)) return 0;
+		count += 1;
+	}
+	return count;
+}
+
+export function keyMatches(data: string, key: PaletteKey): boolean {
+	return matchesKeyId(data, PALETTE_KEY_IDS[key]);
+}
+
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001f\u007f-\u009f]/;
+
+function printableEvent(data: string): string | undefined {
+	const kittyPrintable = decodeKittyPrintable(data);
+	if (kittyPrintable !== undefined) {
+		return isRawPrintableText(kittyPrintable);
+	}
+	const parsed = parseKey(data);
+	if (parsed === Key.space) return " ";
+	return parsed?.length === 1 ? parsed : undefined;
+}
+
+function isRawPrintableText(data: string): string | undefined {
+	if (data.length === 0) return undefined;
+	if (data.includes("\u001b")) return undefined;
+	if (CONTROL_CHAR_PATTERN.test(data)) return undefined;
+	return data;
+}
+
+export function paletteShortcutInput(data: string): string | undefined {
+	const printable = palettePrintableInput(data);
+	if (printable === undefined) return undefined;
+	if (Array.from(printable).length !== 1) return undefined;
+	return printable;
+}
+
+export function palettePrintableInput(data: string): string | undefined {
+	const direct = printableEvent(data);
+	if (direct !== undefined) return direct;
+	let output = "";
+	for (const event of splitInput(data)) {
+		const printable = printableEvent(event);
+		if (printable !== undefined) {
+			output += printable;
+			continue;
+		}
+		const raw = isRawPrintableText(event);
+		if (raw === undefined) return undefined;
+		output += raw;
+	}
+	return output.length > 0 ? output : undefined;
+}

--- a/extensions/continue/src/palette.ts
+++ b/extensions/continue/src/palette.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { loadContinuationConfig } from "./config.ts";
+import { keyMatches, paletteShortcutInput, palettePrintableInput } from "./key-input.ts";
 import { readEffectivePiCompactionSettings } from "./pi-settings.ts";
 import { resolveProjectContext } from "./project.ts";
 import type { ContinuationRuntimeState } from "./runtime.ts";
@@ -30,29 +31,6 @@ interface FocusDraft {
 	actionId: FocusActionId;
 	text: string;
 	cursor: number;
-}
-
-function keyMatches(data: string, key: "up" | "down" | "left" | "right" | "enter" | "escape" | "ctrl-c" | "backspace" | "delete" | "home" | "end"): boolean {
-	if (key === "up") return data === "up" || data === "\u001b[A";
-	if (key === "down") return data === "down" || data === "\u001b[B";
-	if (key === "left") return data === "left" || data === "\u001b[D";
-	if (key === "right") return data === "right" || data === "\u001b[C";
-	if (key === "enter") return data === "enter" || data === "return" || data === "\r" || data === "\n";
-	if (key === "escape") return data === "escape" || data === "\u001b";
-	if (key === "ctrl-c") return data === "ctrl+c" || data === "\u0003";
-	if (key === "backspace") return data === "backspace" || data === "\u007f" || data === "\b";
-	if (key === "delete") return data === "delete" || data === "\u001b[3~";
-	if (key === "home") return data === "home" || data === "\u001b[H" || data === "\u001b[1~";
-	return data === "end" || data === "\u001b[F" || data === "\u001b[4~";
-}
-
-function isPrintable(data: string): boolean {
-	if (data.length === 0) return false;
-	for (const char of data) {
-		const code = char.codePointAt(0);
-		if (code === undefined || code < 32 || code === 127) return false;
-	}
-	return !data.includes("\u001b");
 }
 
 function topLine(theme: PaletteTheme, width: number, title: string): string {
@@ -204,7 +182,7 @@ export class ContinuePaletteComponent {
 			return;
 		}
 		const selectedAction = this.selectedAction();
-		if (data.toLowerCase() === "f" && isFocusActionId(selectedAction.id)) {
+		if (paletteShortcutInput(data)?.toLowerCase() === "f" && isFocusActionId(selectedAction.id)) {
 			this.focusDraft = { actionId: selectedAction.id, text: "", cursor: 0 };
 			this.requestRender();
 		}
@@ -258,14 +236,14 @@ export class ContinuePaletteComponent {
 				const next = nextCursorIndex(draft.text, draft.cursor);
 				draft.text = `${draft.text.slice(0, draft.cursor)}${draft.text.slice(next)}`;
 			}
-		} else if (data === "\u0015") {
+		} else if (keyMatches(data, "ctrl-u")) {
 			draft.text = draft.text.slice(draft.cursor);
 			draft.cursor = 0;
-		} else if (isPrintable(data)) {
-			draft.text = `${draft.text.slice(0, draft.cursor)}${data}${draft.text.slice(draft.cursor)}`;
-			draft.cursor += data.length;
 		} else {
-			return;
+			const printable = palettePrintableInput(data);
+			if (printable === undefined) return;
+			draft.text = `${draft.text.slice(0, draft.cursor)}${printable}${draft.text.slice(draft.cursor)}`;
+			draft.cursor += printable.length;
 		}
 		this.requestRender();
 	}

--- a/extensions/continue/src/text-viewer.ts
+++ b/extensions/continue/src/text-viewer.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { keyRepeat } from "./key-input.ts";
 import { padVisible, stripAnsi, truncateAnsi, visibleWidth } from "./tui-text.ts";
 
 const MIN_WIDTH = 48;
@@ -6,14 +7,6 @@ const TARGET_WIDTH = 92;
 const MAX_HEIGHT = 24;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g;
 const ESCAPE_CHARACTER_PATTERN = /\u001b/g;
-const KITTY_UP_PATTERN = /^\u001b\[1;1(?::[12])?A/;
-const KITTY_DOWN_PATTERN = /^\u001b\[1;1(?::[12])?B/;
-const KITTY_HOME_PATTERN = /^\u001b\[1;1(?::[12])?H/;
-const KITTY_END_PATTERN = /^\u001b\[1;1(?::[12])?F/;
-const KITTY_PAGE_UP_PATTERN = /^\u001b\[5(?:;1)?(?::[12])?~/;
-const KITTY_PAGE_DOWN_PATTERN = /^\u001b\[6(?:;1)?(?::[12])?~/;
-const KITTY_HOME_FUNCTION_PATTERN = /^\u001b\[7(?:;1)?(?::[12])?~/;
-const KITTY_END_FUNCTION_PATTERN = /^\u001b\[8(?:;1)?(?::[12])?~/;
 
 type ViewerColor = "accent" | "border" | "dim" | "muted";
 
@@ -81,49 +74,6 @@ function prepareTextLines(content: string, width: number): string[] {
 		for (const wrapped of wrapPlainLine(line, inner)) result.push(wrapped);
 	}
 	return result.length > 0 ? result : ["(empty)"];
-}
-
-function repeatCount(data: string, sequences: string[]): number {
-	for (const sequence of sequences) {
-		if (data === sequence) return 1;
-		if (sequence.length === 0 || data.length <= sequence.length) continue;
-		if (data.length % sequence.length !== 0) continue;
-		const count = data.length / sequence.length;
-		if (sequence.repeat(count) === data) return count;
-	}
-	return 0;
-}
-
-function repeatedPatternCount(data: string, patterns: RegExp[]): number {
-	for (const pattern of patterns) {
-		let index = 0;
-		let count = 0;
-		while (index < data.length) {
-			const match = pattern.exec(data.slice(index));
-			if (!match || match.index !== 0 || match[0].length === 0) {
-				count = 0;
-				break;
-			}
-			index += match[0].length;
-			count += 1;
-		}
-		if (count > 0) return count;
-	}
-	return 0;
-}
-
-function repeatCountFor(data: string, sequences: string[], patterns: RegExp[]): number {
-	return Math.max(repeatCount(data, sequences), repeatedPatternCount(data, patterns));
-}
-
-function keyRepeat(data: string, key: "up" | "down" | "page-up" | "page-down" | "home" | "end" | "close"): number {
-	if (key === "up") return repeatCountFor(data, ["up", "k", "\u001b[A", "\u001bOA"], [KITTY_UP_PATTERN]);
-	if (key === "down") return repeatCountFor(data, ["down", "j", "\u001b[B", "\u001bOB"], [KITTY_DOWN_PATTERN]);
-	if (key === "page-up") return repeatCountFor(data, ["pageup", "page-up", "\u001b[5~", "\u001b[[5~"], [KITTY_PAGE_UP_PATTERN]);
-	if (key === "page-down") return repeatCountFor(data, ["pagedown", "page-down", "\u001b[6~", "\u001b[[6~"], [KITTY_PAGE_DOWN_PATTERN]);
-	if (key === "home") return repeatCountFor(data, ["home", "\u001b[H", "\u001bOH", "\u001b[1~", "\u001b[7~"], [KITTY_HOME_PATTERN, KITTY_HOME_FUNCTION_PATTERN]);
-	if (key === "end") return repeatCountFor(data, ["end", "\u001b[F", "\u001bOF", "\u001b[4~", "\u001b[8~"], [KITTY_END_PATTERN, KITTY_END_FUNCTION_PATTERN]);
-	return repeatCount(data, ["enter", "return", "\r", "\n", "escape", "q", "\u001b", "ctrl+c", "\u0003"]);
 }
 
 export class ScrollableTextOverlay {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.74.0",
-    "@earendil-works/pi-coding-agent": ">=0.74.0"
+    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-tui": ">=0.74.0"
   },
   "pi": {
     "extensions": [
@@ -56,6 +57,7 @@
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.74.0",
     "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
     "@types/node": "^25.6.1",
     "typescript": "^6.0.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: ^0.74.0
         version: 0.74.0(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: ^0.74.0
+        version: 0.74.0
       '@types/node':
         specifier: ^25.6.1
         version: 25.6.1

--- a/tests/docs.test.ts
+++ b/tests/docs.test.ts
@@ -150,6 +150,7 @@ test("package metadata and package contents align with the public contract", () 
 	]);
 	assert.equal(packageJson.peerDependencies["@earendil-works/pi-ai"], ">=0.74.0");
 	assert.equal(packageJson.peerDependencies["@earendil-works/pi-coding-agent"], ">=0.74.0");
+	assert.equal(packageJson.peerDependencies["@earendil-works/pi-tui"], ">=0.74.0");
 	assert.deepEqual(packageJson.pi.extensions, ["./extensions/continue/index.ts"]);
 	assert.equal(packageJson.pi.image, "https://raw.githubusercontent.com/Tiziano-AI/pi-continue/v0.8.2/assets/gallery/pi-continue-gallery.webp");
 	assert.equal(existsSync("assets/gallery/pi-continue-gallery.webp"), true);

--- a/tests/palette.test.ts
+++ b/tests/palette.test.ts
@@ -80,10 +80,44 @@ test("ContinuePaletteComponent captures optional focus from the focus screen", (
 		renders += 1;
 	});
 	component.handleInput("f");
-	for (const char of "finish tests") component.handleInput(char);
+	component.handleInput("finish tests");
 	component.handleInput("enter");
 	assert.deepEqual(selected, { kind: "continue", mode: "steer", instructions: "finish tests" });
-	assert.equal(renders, "finish tests".length + 1);
+	assert.equal(renders, 2);
+});
+
+test("ContinuePaletteComponent opens focus mode with CSI-u encoded f shortcut", () => {
+	let selected;
+	const component = new ContinuePaletteComponent(createSnapshot(), theme, (result) => {
+		selected = result;
+	}, () => {});
+	component.handleInput("\x1b[102;1u");
+	component.handleInput("via kitty");
+	component.handleInput("enter");
+	assert.deepEqual(selected, { kind: "continue", mode: "steer", instructions: "via kitty" });
+});
+
+test("ContinuePaletteComponent keeps Unicode focus text", () => {
+	let selected;
+	const component = new ContinuePaletteComponent(createSnapshot(), theme, (result) => {
+		selected = result;
+	}, () => {});
+	component.handleInput("f");
+	for (const ch of "测试🙂é") component.handleInput(ch);
+	component.handleInput("enter");
+	assert.deepEqual(selected, { kind: "continue", mode: "steer", instructions: "测试🙂é" });
+});
+
+test("ContinuePaletteComponent rejects CSI-u encoded controls in focus text", () => {
+	let selected;
+	const component = new ContinuePaletteComponent(createSnapshot(), theme, (result) => {
+		selected = result;
+	}, () => {});
+	component.handleInput("f");
+	component.handleInput("\x1b[133;1u");
+	component.handleInput("\x1b[127;1u");
+	component.handleInput("enter");
+	assert.deepEqual(selected, { kind: "continue", mode: "steer", instructions: undefined });
 });
 
 test("ContinuePaletteComponent captures queue and preview focus actions", () => {
@@ -119,6 +153,18 @@ test("ContinuePaletteComponent backs out of focus mode without saving hidden tex
 	for (const char of "do not keep") component.handleInput(char);
 	component.handleInput("escape");
 	component.handleInput("enter");
+	assert.deepEqual(selected, { kind: "continue", mode: "steer", instructions: undefined });
+});
+
+test("ContinuePaletteComponent handles Pi TUI escape and enter key events", () => {
+	let selected;
+	const component = new ContinuePaletteComponent(createSnapshot(), theme, (result) => {
+		selected = result;
+	}, () => {});
+	component.handleInput("f");
+	for (const char of "do not keep") component.handleInput(char);
+	component.handleInput("\x1b[27;1u");
+	component.handleInput("\x1b[13;1u");
 	assert.deepEqual(selected, { kind: "continue", mode: "steer", instructions: undefined });
 });
 

--- a/tests/text-viewer.test.ts
+++ b/tests/text-viewer.test.ts
@@ -44,6 +44,34 @@ test("ScrollableTextOverlay scrolls repeated held-arrow chunks", () => {
 	assert.match(afterUp, /\| line 2\s+\|/);
 });
 
+test("ScrollableTextOverlay closes on CSI-u Escape", () => {
+	let closed = 0;
+	const overlay = new ScrollableTextOverlay(
+		{ title: "preview", content: "x" },
+		theme,
+		() => {
+			closed += 1;
+		},
+		() => {},
+	);
+	overlay.handleInput("\u001b[27;1u");
+	assert.equal(closed, 1);
+});
+
+test("ScrollableTextOverlay closes on CSI-u Enter", () => {
+	let closed = 0;
+	const overlay = new ScrollableTextOverlay(
+		{ title: "preview", content: "x" },
+		theme,
+		() => {
+			closed += 1;
+		},
+		() => {},
+	);
+	overlay.handleInput("\u001b[13;1u");
+	assert.equal(closed, 1);
+});
+
 test("ScrollableTextOverlay scrolls Kitty repeat key events", () => {
 	let renders = 0;
 	const lines = Array.from({ length: 50 }, (_entry, index) => `line ${index + 1}`).join("\n");


### PR DESCRIPTION
## Summary
- Replace hand-written continuation overlay key parsing with Pi TUI keyboard helpers.
- Add direct @earendil-works/pi-tui peer/dev dependency usage for key matching.
- Cover CSI-u Escape/Enter, repeated key events, and palette printable input handling in tests.

Fixes #2

## Validation
- git diff --check origin/main..HEAD
- pnpm run gate (212 pass, 0 fail)