### PR TITLE
Reuse Continuation Ledger overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Default package config:
   "appendModifiedFileTags": true,
   "promptOverridePolicy": "project-override",
   "showAfterCompact": true,
-  "singleLedgerOverlay": true
+  "singleLedgerOverlay": true,
+  "ledgerOverlayAutoClose": "disabled"
 }
 ```
 
@@ -147,6 +148,7 @@ Common settings:
 | `promptOverridePolicy` | Chooses project overrides, global overrides, or package defaults. |
 | `showAfterCompact` | `true` by default; surfaces the rendered brief in a temporary TUI panel right after each successful extension-owned compaction. Set `false` for a silent handoff. |
 | `singleLedgerOverlay` | `true` by default; reuses and focuses one package-owned Ledger panel instead of stacking a new panel after every compaction. Set `false` to keep the older stacked-panel behavior. |
+| `ledgerOverlayAutoClose` | `"disabled"` by default. Set `"completed"` to close package-owned Ledger panels after a successful same-session continuation ends, or `"all"` to close them after any terminal continuation resume outcome. |
 
 `/continue settings` also includes a handoff trigger control. It shows one human-facing trigger token count and writes Pi core `compaction.reserveTokens` in `.pi/settings.json` or the global Pi settings file, not a package config key.
 
@@ -226,6 +228,7 @@ What can change:
 - `continuationArtifactMode: "always"` writes the rendered brief under `.pi/continue/` after successful extension-owned compaction.
 - `continuationArtifactMode: "off"` writes no continuation artifact.
 - `showAfterCompact: true` (default) surfaces the rendered brief in a TUI overlay right after compaction completes; set `false` for a silent handoff.
+- `ledgerOverlayAutoClose: "completed"` or `"all"` can close package-owned Ledger panels when the continuation resume settles; the default `"disabled"` leaves them open for manual review.
 - `agentGuideSyncMode: "off"` is the default.
 - `agentGuideSyncMode: "always"` writes only a full non-null `agentGuideUpdate.content` replacement to the configured agent-guide path.
 - Writes are normalized and skipped when content is unchanged.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Default package config:
   "appendReadFileTags": false,
   "appendModifiedFileTags": true,
   "promptOverridePolicy": "project-override",
-  "showAfterCompact": true
+  "showAfterCompact": true,
+  "singleLedgerOverlay": true
 }
 ```
 
@@ -145,6 +146,7 @@ Common settings:
 | `appendModifiedFileTags` | `true` by default; when true, appends current compaction modified-file tags. |
 | `promptOverridePolicy` | Chooses project overrides, global overrides, or package defaults. |
 | `showAfterCompact` | `true` by default; surfaces the rendered brief in a temporary TUI panel right after each successful extension-owned compaction. Set `false` for a silent handoff. |
+| `singleLedgerOverlay` | `true` by default; reuses and focuses one package-owned Ledger panel instead of stacking a new panel after every compaction. Set `false` to keep the older stacked-panel behavior. |
 
 `/continue settings` also includes a handoff trigger control. It shows one human-facing trigger token count and writes Pi core `compaction.reserveTokens` in `.pi/settings.json` or the global Pi settings file, not a package config key.
 

--- a/examples/pi-continue.json
+++ b/examples/pi-continue.json
@@ -11,5 +11,6 @@
   "appendReadFileTags": false,
   "appendModifiedFileTags": true,
   "promptOverridePolicy": "project-override",
-  "showAfterCompact": true
+  "showAfterCompact": true,
+  "singleLedgerOverlay": true
 }

--- a/examples/pi-continue.json
+++ b/examples/pi-continue.json
@@ -12,5 +12,6 @@
   "appendModifiedFileTags": true,
   "promptOverridePolicy": "project-override",
   "showAfterCompact": true,
-  "singleLedgerOverlay": true
+  "singleLedgerOverlay": true,
+  "ledgerOverlayAutoClose": "disabled"
 }

--- a/extensions/continue/index.ts
+++ b/extensions/continue/index.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { loadHistoryPromptAssets } from "./src/assets.ts";
 import { parseHistoryArtifacts } from "./src/blocks.ts";
 import { splitContinueSubcommand, shouldOpenContinuePalette } from "./src/command-shape.ts";
@@ -23,7 +23,7 @@ import {
 } from "./src/continuation-event.ts";
 import { buildContinuationDetails, buildContinuationSynthesisTelemetry, parseContinuationDetails } from "./src/details.ts";
 import { SYNTHESIS_ABORT_MESSAGE } from "./src/synthesis-error.ts";
-import { buildLedgerSnapshot, clearContinuationLedgerOverlay, showContinuationLedgerOverlaySoon } from "./src/ledger-viewer.ts";
+import { buildLedgerSnapshot, clearContinuationLedgerOverlay, closeContinuationLedgerOverlays, showContinuationLedgerOverlaySoon } from "./src/ledger-viewer.ts";
 import { runMidRunGuard } from "./src/mid-run-guard.ts";
 import { PromptPassError, runPromptPass } from "./src/model.ts";
 import { loadPiInternals } from "./src/pi-internals.ts";
@@ -49,7 +49,7 @@ import {
 	NATIVE_COMPACTION_FALLBACK_FAILURE,
 	clearPendingResumeDispatch,
 } from "./src/resume-proof.ts";
-import type { AgentGuideWriteStatus, ContinuationSynthesisFailure, ContinuationSynthesisTelemetry, ParsedHistoryArtifacts, PendingOutputWrite, WriteMode } from "./src/types.ts";
+import type { AgentGuideWriteStatus, ContinuationResumeStatus, ContinuationSynthesisFailure, ContinuationSynthesisTelemetry, ParsedHistoryArtifacts, PendingOutputWrite, ResolvedProjectContext, WriteMode } from "./src/types.ts";
 import {
 	clearWorkingVisuals,
 	settleWorkingVisuals,
@@ -63,6 +63,19 @@ function decideAgentGuideWriteStatus(writeMode: WriteMode, agentGuideMd: string 
 
 function isAssistantMessage(message: unknown): message is AssistantMessage {
 	return typeof message === "object" && message !== null && "role" in message && message.role === "assistant";
+}
+
+async function maybeAutoCloseLedgerOverlays(
+	pi: Pick<ExtensionAPI, "exec">,
+	ctx: Pick<ExtensionContext, "cwd" | "sessionManager">,
+	resumeStatus: ContinuationResumeStatus,
+	projectContext?: ResolvedProjectContext,
+): Promise<void> {
+	const resolvedContext = projectContext ?? await resolveProjectContext(pi, ctx.cwd, ctx.sessionManager.getSessionId());
+	const config = loadContinuationConfig(resolvedContext.projectRoot);
+	if (config.ledgerOverlayAutoClose === "disabled") return;
+	if (config.ledgerOverlayAutoClose === "completed" && resumeStatus !== "completed") return;
+	closeContinuationLedgerOverlays();
 }
 
 const OUTPUT_WRITE_FAILURE = "Output write failed; check the configured path and permissions.";
@@ -94,6 +107,19 @@ function normalizeSynthesisFailure(error: unknown): ContinuationSynthesisFailure
 export default function (pi: ExtensionAPI) {
 	const pendingOutputWrites = new Map<string, PendingOutputWrite>();
 	const runtime = createContinuationRuntimeState();
+	const projectContexts = new Map<string, ResolvedProjectContext>();
+
+	function projectContextForEvent(eventId: string): ResolvedProjectContext | undefined {
+		return projectContexts.get(eventId);
+	}
+
+	function rememberProjectContext(eventId: string, projectContext: ResolvedProjectContext): void {
+		projectContexts.set(eventId, projectContext);
+	}
+
+	function cleanupProjectContext(eventId: string): void {
+		projectContexts.delete(eventId);
+	}
 
 	function cleanupPendingOutputWrites(eventId: string): void {
 		let removed = false;
@@ -107,6 +133,28 @@ export default function (pi: ExtensionAPI) {
 		}
 	}
 
+	function cleanupContinuationSideEffects(eventId: string): void {
+		cleanupPendingOutputWrites(eventId);
+		cleanupProjectContext(eventId);
+	}
+
+	function continuationFailureHasResume(eventId: string): boolean {
+		const event = runtime.latestEvent;
+		return event?.id === eventId && event.resume.status !== "not-requested";
+	}
+
+	function cleanupContinuationFailureSideEffects(ctx: ExtensionContext, eventId: string): void {
+		const projectContext = projectContextForEvent(eventId);
+		const shouldAutoClose = continuationFailureHasResume(eventId);
+		cleanupContinuationSideEffects(eventId);
+		if (shouldAutoClose) void maybeAutoCloseLedgerOverlays(pi, ctx, "failed", projectContext).catch(() => undefined);
+	}
+
+	async function settleContinuationWithAutoClose(ctx: ExtensionContext, settlement: { eventId: string; status: ContinuationResumeStatus }): Promise<void> {
+		await maybeAutoCloseLedgerOverlays(pi, ctx, settlement.status, projectContextForEvent(settlement.eventId));
+		cleanupProjectContext(settlement.eventId);
+	}
+
 	pi.registerCommand("continue", {
 		description: "Save a same-session handoff, resume this run, or inspect continuation settings.",
 		getArgumentCompletions: getContinueArgumentCompletions,
@@ -114,7 +162,15 @@ export default function (pi: ExtensionAPI) {
 			if (shouldOpenContinuePalette(args, ctx.hasUI)) {
 				const palette = await showContinuePalette(pi, ctx, runtime);
 				if (palette.supported) {
-					if (palette.result) await runContinuePaletteResult(pi, ctx, runtime, palette.result, (eventId) => cleanupPendingOutputWrites(eventId));
+					if (palette.result) {
+						await runContinuePaletteResult(
+							pi,
+							ctx,
+							runtime,
+							palette.result,
+							(eventId) => cleanupContinuationFailureSideEffects(ctx, eventId),
+						);
+					}
 					return;
 				}
 			}
@@ -144,7 +200,7 @@ export default function (pi: ExtensionAPI) {
 				ctx,
 				runtime,
 				args,
-				(eventId) => cleanupPendingOutputWrites(eventId),
+				(eventId) => cleanupContinuationFailureSideEffects(ctx, eventId),
 			);
 		},
 	});
@@ -174,6 +230,7 @@ export default function (pi: ExtensionAPI) {
 		const settlement = failRunningAwaitingContinuationResume(runtime, "Continuation resume did not produce an assistant response.");
 		if (settlement) {
 			settleWorkingVisuals(ctx, runtime, settlement.eventId);
+			await settleContinuationWithAutoClose(ctx, settlement);
 			return;
 		}
 		armDeferredResumeStartTimeout(ctx, runtime);
@@ -184,10 +241,11 @@ export default function (pi: ExtensionAPI) {
 		const settlement = settleAwaitingContinuationResumeFromAssistant(runtime, event.message);
 		if (!settlement) return;
 		settleWorkingVisuals(ctx, runtime, settlement.eventId);
+		await settleContinuationWithAutoClose(ctx, settlement);
 	});
 
 	pi.on("context", async (event, ctx) => {
-		await runMidRunGuard(pi, ctx, runtime, event.messages, (eventId) => cleanupPendingOutputWrites(eventId));
+		await runMidRunGuard(pi, ctx, runtime, event.messages, (eventId) => cleanupContinuationFailureSideEffects(ctx, eventId));
 	});
 
 	pi.on("session_before_compact", async (event, ctx) => {
@@ -197,6 +255,7 @@ export default function (pi: ExtensionAPI) {
 		const ownerStillActive = () => isActiveRunningContinuationEvent(runtime, ownerEventId);
 		const ownerLostResult = () => ownerStillActive() ? undefined : { cancel: true as const };
 		const projectContext = await resolveProjectContext(pi, ctx.cwd, sessionId);
+		rememberProjectContext(ownerEventId, projectContext);
 		const ownerLostAfterProjectContext = ownerLostResult();
 		if (ownerLostAfterProjectContext) return ownerLostAfterProjectContext;
 		const config = loadContinuationConfig(projectContext.projectRoot);
@@ -362,9 +421,10 @@ export default function (pi: ExtensionAPI) {
 		const ledger = canUpdateLedger
 			? buildLedgerSnapshot(event.compactionEntry.summary, ledgerOwnerId, event.compactionEntry.id)
 			: undefined;
+		let projectContext: ResolvedProjectContext | undefined;
 		if (ledger) {
 			runtime.latestLedger = ledger;
-			const projectContext = await resolveProjectContext(pi, ctx.cwd, ctx.sessionManager.getSessionId());
+			projectContext = await resolveProjectContext(pi, ctx.cwd, ctx.sessionManager.getSessionId());
 			const config = loadContinuationConfig(projectContext.projectRoot);
 			if (config.enabled && config.showAfterCompact) {
 				showContinuationLedgerOverlaySoon(ctx, ledger, config.singleLedgerOverlay, (reason) => {
@@ -398,6 +458,7 @@ export default function (pi: ExtensionAPI) {
 			ctx.ui.notify("Agent guide unchanged; no full replacement was produced.", "info");
 		}
 		if (acceptedActiveProof && activeEventId) {
+			if (projectContext) rememberProjectContext(activeEventId, projectContext);
 			dispatchVerifiedContinuationResume(ctx, runtime, activeEventId);
 		}
 	});
@@ -405,6 +466,7 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_shutdown", async (_event, ctx) => {
 		abandonActiveContinuationEvent(runtime, "Pi session shut down before continuation finished settling.");
 		pendingOutputWrites.clear();
+		projectContexts.clear();
 		clearWorkingVisuals(ctx, runtime);
 		runtime.compactionRunning = false;
 		runtime.guardFailureKey = undefined;

--- a/extensions/continue/index.ts
+++ b/extensions/continue/index.ts
@@ -23,7 +23,7 @@ import {
 } from "./src/continuation-event.ts";
 import { buildContinuationDetails, buildContinuationSynthesisTelemetry, parseContinuationDetails } from "./src/details.ts";
 import { SYNTHESIS_ABORT_MESSAGE } from "./src/synthesis-error.ts";
-import { buildLedgerSnapshot, showContinuationLedgerOverlaySoon } from "./src/ledger-viewer.ts";
+import { buildLedgerSnapshot, clearContinuationLedgerOverlay, showContinuationLedgerOverlaySoon } from "./src/ledger-viewer.ts";
 import { runMidRunGuard } from "./src/mid-run-guard.ts";
 import { PromptPassError, runPromptPass } from "./src/model.ts";
 import { loadPiInternals } from "./src/pi-internals.ts";
@@ -124,7 +124,7 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 			if (subcommand?.name === "ledger") {
-				await runLedgerCommand(ctx, runtime);
+				await runLedgerCommand(pi, ctx, runtime);
 				return;
 			}
 			if (subcommand?.name === "settings") {
@@ -367,7 +367,7 @@ export default function (pi: ExtensionAPI) {
 			const projectContext = await resolveProjectContext(pi, ctx.cwd, ctx.sessionManager.getSessionId());
 			const config = loadContinuationConfig(projectContext.projectRoot);
 			if (config.enabled && config.showAfterCompact) {
-				showContinuationLedgerOverlaySoon(ctx, ledger, (reason) => {
+				showContinuationLedgerOverlaySoon(ctx, ledger, config.singleLedgerOverlay, (reason) => {
 					if (ctx.hasUI) ctx.ui.notify(`Could not open Continuation Ledger: ${reason}`, "error");
 				});
 			}
@@ -411,5 +411,6 @@ export default function (pi: ExtensionAPI) {
 		clearResumeStartTimeout(runtime);
 		clearPendingResumeDispatch(runtime);
 		runtime.awaitingResumeEventId = undefined;
+		clearContinuationLedgerOverlay();
 	});
 }

--- a/extensions/continue/src/command-runner.ts
+++ b/extensions/continue/src/command-runner.ts
@@ -43,7 +43,7 @@ export async function runContinuePaletteResult(
 		return;
 	}
 	if (result.kind === "ledger") {
-		await runLedgerCommand(ctx, runtime);
+		await runLedgerCommand(pi, ctx, runtime);
 		return;
 	}
 	if (result.kind === "settings") {

--- a/extensions/continue/src/commands.ts
+++ b/extensions/continue/src/commands.ts
@@ -102,6 +102,7 @@ async function chooseModel(ctx: ExtensionCommandContext): Promise<string | undef
 }
 
 const ALL_REASONING_OPTIONS: readonly ContinuationConfig["reasoning"][] = ["inherit", "off", "minimal", "low", "medium", "high", "xhigh"];
+const LEDGER_OVERLAY_AUTO_CLOSE_OPTIONS: readonly ContinuationConfig["ledgerOverlayAutoClose"][] = ["disabled", "completed", "all"];
 
 /** Return operator-selectable reasoning levels, hiding levels unsupported by the resolved summarizer model. */
 export function getReasoningOptionsForModel(model: Model<Api> | undefined): ContinuationConfig["reasoning"][] {
@@ -145,6 +146,7 @@ const CONFIG_KEYS = [
 	"promptOverridePolicy",
 	"showAfterCompact",
 	"singleLedgerOverlay",
+	"ledgerOverlayAutoClose",
 ] as const;
 
 function setConfigPatchValue<Key extends keyof ContinuationConfig>(patch: Partial<ContinuationConfig>, key: Key, value: ContinuationConfig[Key]): void {
@@ -201,6 +203,7 @@ export async function runSettingsDialog(pi: ExtensionAPI, ctx: ExtensionCommandC
 			`Prompt override policy: ${config.promptOverridePolicy}`,
 			`Show brief after compaction: ${config.showAfterCompact ? "yes" : "no"}`,
 			`Single Ledger overlay: ${config.singleLedgerOverlay ? "yes" : "no"}`,
+			`Auto-close Ledger overlays: ${config.ledgerOverlayAutoClose}`,
 			`Reset ${scope} settings`,
 			"Done",
 		]);
@@ -311,6 +314,13 @@ export async function runSettingsDialog(pi: ExtensionAPI, ctx: ExtensionCommandC
 				...current,
 				singleLedgerOverlay: !current.singleLedgerOverlay,
 			}));
+			continue;
+		}
+		if (selected.startsWith("Auto-close Ledger overlays:")) {
+			config = await updateSetting(scope, projectContext.projectRoot, config, async (current) => {
+				const next = await ctx.ui.select("Auto-close Ledger overlays", [...LEDGER_OVERLAY_AUTO_CLOSE_OPTIONS]);
+				return next ? { ...current, ledgerOverlayAutoClose: next as ContinuationConfig["ledgerOverlayAutoClose"] } : undefined;
+			});
 			continue;
 		}
 		if (selected === `Reset ${scope} settings`) {

--- a/extensions/continue/src/commands.ts
+++ b/extensions/continue/src/commands.ts
@@ -144,6 +144,7 @@ const CONFIG_KEYS = [
 	"appendModifiedFileTags",
 	"promptOverridePolicy",
 	"showAfterCompact",
+	"singleLedgerOverlay",
 ] as const;
 
 function setConfigPatchValue<Key extends keyof ContinuationConfig>(patch: Partial<ContinuationConfig>, key: Key, value: ContinuationConfig[Key]): void {
@@ -199,6 +200,7 @@ export async function runSettingsDialog(pi: ExtensionAPI, ctx: ExtensionCommandC
 			`Append modified file tags: ${config.appendModifiedFileTags ? "yes" : "no"}`,
 			`Prompt override policy: ${config.promptOverridePolicy}`,
 			`Show brief after compaction: ${config.showAfterCompact ? "yes" : "no"}`,
+			`Single Ledger overlay: ${config.singleLedgerOverlay ? "yes" : "no"}`,
 			`Reset ${scope} settings`,
 			"Done",
 		]);
@@ -304,6 +306,13 @@ export async function runSettingsDialog(pi: ExtensionAPI, ctx: ExtensionCommandC
 			}));
 			continue;
 		}
+		if (selected.startsWith("Single Ledger overlay:")) {
+			config = await updateSetting(scope, projectContext.projectRoot, config, async (current) => ({
+				...current,
+				singleLedgerOverlay: !current.singleLedgerOverlay,
+			}));
+			continue;
+		}
 		if (selected === `Reset ${scope} settings`) {
 			const confirmed = await ctx.ui.confirm(`Reset ${scope} settings?`, `Delete the ${scope} settings file and fall back to global/default settings?`);
 			if (confirmed) {
@@ -339,8 +348,10 @@ export async function runStatusCommand(pi: ExtensionAPI, ctx: ExtensionCommandCo
 }
 
 /** Show the latest in-memory Continuation Ledger without mutating the transcript. */
-export async function runLedgerCommand(ctx: ExtensionCommandContext, runtime: ContinuationRuntimeState): Promise<void> {
-	await showLatestContinuationLedger(ctx, getLatestContinuationLedger(runtime));
+export async function runLedgerCommand(pi: ExtensionAPI, ctx: ExtensionCommandContext, runtime: ContinuationRuntimeState): Promise<void> {
+	const projectContext = await resolveProjectContext(pi, ctx.cwd, ctx.sessionManager.getSessionId());
+	const config = loadContinuationConfig(projectContext.projectRoot);
+	await showLatestContinuationLedger(ctx, getLatestContinuationLedger(runtime), config.singleLedgerOverlay);
 }
 
 /** Reset scoped config. */

--- a/extensions/continue/src/config.ts
+++ b/extensions/continue/src/config.ts
@@ -52,6 +52,7 @@ export const DEFAULT_CONTINUE_CONFIG: ContinuationConfig = {
 	appendModifiedFileTags: true,
 	promptOverridePolicy: "project-override",
 	showAfterCompact: true,
+	singleLedgerOverlay: true,
 };
 
 interface PartialContinuationConfig {
@@ -68,6 +69,7 @@ interface PartialContinuationConfig {
 	appendModifiedFileTags?: boolean;
 	promptOverridePolicy?: string;
 	showAfterCompact?: boolean;
+	singleLedgerOverlay?: boolean;
 }
 
 export interface ContinuationConfigPatch {
@@ -84,6 +86,7 @@ export interface ContinuationConfigPatch {
 	appendModifiedFileTags?: boolean;
 	promptOverridePolicy?: PromptOverridePolicy;
 	showAfterCompact?: boolean;
+	singleLedgerOverlay?: boolean;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -136,6 +139,8 @@ function parsePartialConfig(value: unknown): PartialContinuationConfig {
 	if (promptOverridePolicy !== undefined) result.promptOverridePolicy = promptOverridePolicy;
 	const showAfterCompact = asBoolean(value.showAfterCompact);
 	if (showAfterCompact !== undefined) result.showAfterCompact = showAfterCompact;
+	const singleLedgerOverlay = asBoolean(value.singleLedgerOverlay);
+	if (singleLedgerOverlay !== undefined) result.singleLedgerOverlay = singleLedgerOverlay;
 	return result;
 }
 
@@ -201,6 +206,7 @@ function normalizeConfig(partial: PartialContinuationConfig): ContinuationConfig
 		appendModifiedFileTags: partial.appendModifiedFileTags ?? DEFAULT_CONTINUE_CONFIG.appendModifiedFileTags,
 		promptOverridePolicy: normalizePromptOverridePolicy(partial.promptOverridePolicy),
 		showAfterCompact: partial.showAfterCompact ?? DEFAULT_CONTINUE_CONFIG.showAfterCompact,
+		singleLedgerOverlay: partial.singleLedgerOverlay ?? DEFAULT_CONTINUE_CONFIG.singleLedgerOverlay,
 	};
 }
 

--- a/extensions/continue/src/config.ts
+++ b/extensions/continue/src/config.ts
@@ -5,6 +5,7 @@ import type {
 	ConfigScope,
 	ContinuationConfig,
 	ContinuationReasoning,
+	LedgerOverlayAutoClose,
 	PromptOverridePolicy,
 	WriteMode,
 } from "./types.ts";
@@ -25,6 +26,7 @@ const PROMPT_OVERRIDE_POLICIES = new Set<PromptOverridePolicy>([
 	"project-override",
 ]);
 const WRITE_MODES = new Set<WriteMode>(["always", "off"]);
+const LEDGER_OVERLAY_AUTO_CLOSE_VALUES = new Set<LedgerOverlayAutoClose>(["disabled", "completed", "all"]);
 const mutationQueues = new Map<string, Promise<void>>();
 
 async function withConfigMutationQueue(path: string, work: () => Promise<void>): Promise<void> {
@@ -53,6 +55,7 @@ export const DEFAULT_CONTINUE_CONFIG: ContinuationConfig = {
 	promptOverridePolicy: "project-override",
 	showAfterCompact: true,
 	singleLedgerOverlay: true,
+	ledgerOverlayAutoClose: "disabled",
 };
 
 interface PartialContinuationConfig {
@@ -70,6 +73,7 @@ interface PartialContinuationConfig {
 	promptOverridePolicy?: string;
 	showAfterCompact?: boolean;
 	singleLedgerOverlay?: boolean;
+	ledgerOverlayAutoClose?: string;
 }
 
 export interface ContinuationConfigPatch {
@@ -87,6 +91,7 @@ export interface ContinuationConfigPatch {
 	promptOverridePolicy?: PromptOverridePolicy;
 	showAfterCompact?: boolean;
 	singleLedgerOverlay?: boolean;
+	ledgerOverlayAutoClose?: LedgerOverlayAutoClose;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -141,6 +146,8 @@ function parsePartialConfig(value: unknown): PartialContinuationConfig {
 	if (showAfterCompact !== undefined) result.showAfterCompact = showAfterCompact;
 	const singleLedgerOverlay = asBoolean(value.singleLedgerOverlay);
 	if (singleLedgerOverlay !== undefined) result.singleLedgerOverlay = singleLedgerOverlay;
+	const ledgerOverlayAutoClose = asString(value.ledgerOverlayAutoClose);
+	if (ledgerOverlayAutoClose !== undefined) result.ledgerOverlayAutoClose = ledgerOverlayAutoClose;
 	return result;
 }
 
@@ -175,6 +182,12 @@ function normalizeWriteMode(value: string | undefined, fallback: WriteMode): Wri
 		: fallback;
 }
 
+function normalizeLedgerOverlayAutoClose(value: string | undefined): LedgerOverlayAutoClose {
+	return value !== undefined && LEDGER_OVERLAY_AUTO_CLOSE_VALUES.has(value as LedgerOverlayAutoClose)
+		? (value as LedgerOverlayAutoClose)
+		: DEFAULT_CONTINUE_CONFIG.ledgerOverlayAutoClose;
+}
+
 function normalizePath(value: string | undefined, fallback: string): string {
 	const trimmed = value?.trim();
 	return trimmed && trimmed.length > 0 ? trimmed : fallback;
@@ -207,6 +220,7 @@ function normalizeConfig(partial: PartialContinuationConfig): ContinuationConfig
 		promptOverridePolicy: normalizePromptOverridePolicy(partial.promptOverridePolicy),
 		showAfterCompact: partial.showAfterCompact ?? DEFAULT_CONTINUE_CONFIG.showAfterCompact,
 		singleLedgerOverlay: partial.singleLedgerOverlay ?? DEFAULT_CONTINUE_CONFIG.singleLedgerOverlay,
+		ledgerOverlayAutoClose: normalizeLedgerOverlayAutoClose(partial.ledgerOverlayAutoClose),
 	};
 }
 

--- a/extensions/continue/src/ledger-viewer.ts
+++ b/extensions/continue/src/ledger-viewer.ts
@@ -1,12 +1,25 @@
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { extractTaggedBlock } from "./blocks.ts";
-import { ScrollableTextOverlay, sanitizeOverlayText, showScrollableTextOverlay } from "./text-viewer.ts";
+import { ScrollableTextOverlay, sanitizeOverlayText } from "./text-viewer.ts";
 import type { ContinuationLedgerSnapshot } from "./types.ts";
 
 interface LedgerTheme {
 	fg(color: "accent" | "border" | "dim" | "muted", text: string): string;
 	bold(text: string): string;
 }
+
+interface LedgerOverlayHandle {
+	focus(): void;
+	hide(): void;
+}
+
+interface TrackedLedgerOverlay {
+	overlay: ContinuationLedgerOverlay;
+	handle: LedgerOverlayHandle | undefined;
+}
+
+const openLedgerOverlays = new Set<TrackedLedgerOverlay>();
+let activeLedgerOverlay: TrackedLedgerOverlay | undefined;
 
 function ledgerHeaderLines(ledger: ContinuationLedgerSnapshot): string[] {
 	return [
@@ -22,17 +35,37 @@ export class ContinuationLedgerOverlay extends ScrollableTextOverlay {
 		done: () => void,
 		requestRender: () => void,
 	) {
-		super(
-			{
-				title: "Continuation Ledger",
-				content: ledger.content,
-				headerLines: ledgerHeaderLines(ledger),
-			},
-			theme,
-			done,
-			requestRender,
-		);
+		super(ledgerOverlayOptions(ledger), theme, done, requestRender);
 	}
+
+	setLedger(ledger: ContinuationLedgerSnapshot): void {
+		this.update(ledgerOverlayOptions(ledger));
+	}
+}
+
+function ledgerOverlayOptions(ledger: ContinuationLedgerSnapshot) {
+	return {
+		title: "Continuation Ledger",
+		content: ledger.content,
+		headerLines: ledgerHeaderLines(ledger),
+	};
+}
+
+function forgetLedgerOverlay(entry: TrackedLedgerOverlay | undefined): void {
+	if (!entry) return;
+	openLedgerOverlays.delete(entry);
+	if (activeLedgerOverlay === entry) activeLedgerOverlay = undefined;
+}
+
+export function closeContinuationLedgerOverlays(): void {
+	const open = [...openLedgerOverlays];
+	openLedgerOverlays.clear();
+	activeLedgerOverlay = undefined;
+	for (const entry of open.reverse()) entry.handle?.hide();
+}
+
+export function clearContinuationLedgerOverlay(): void {
+	closeContinuationLedgerOverlays();
 }
 
 export function extractContinuationLedger(summary: string): string | undefined {
@@ -57,13 +90,24 @@ export function buildLedgerSnapshot(
 export async function showContinuationLedgerOverlay(
 	ctx: ExtensionContext,
 	ledger: ContinuationLedgerSnapshot,
+	singleOverlay = true,
 ): Promise<boolean> {
 	if (!ctx.hasUI) return false;
+	if (singleOverlay && activeLedgerOverlay) {
+		activeLedgerOverlay.overlay.setLedger(ledger);
+		activeLedgerOverlay.handle?.focus();
+		return true;
+	}
 	let supported = false;
-	await ctx.ui.custom<void>(
+	let entry: TrackedLedgerOverlay | undefined;
+	const lifecycle = ctx.ui.custom<void>(
 		(tui, theme, _keybindings, done) => {
 			supported = true;
-			return new ContinuationLedgerOverlay(ledger, theme, () => done(), () => tui.requestRender());
+			const overlay = new ContinuationLedgerOverlay(ledger, theme, () => done(), () => tui.requestRender());
+			entry = { overlay, handle: undefined };
+			openLedgerOverlays.add(entry);
+			if (singleOverlay) activeLedgerOverlay = entry;
+			return overlay;
 		},
 		{
 			overlay: true,
@@ -74,17 +118,25 @@ export async function showContinuationLedgerOverlay(
 				anchor: "center",
 				margin: 1,
 			},
+			onHandle: (handle) => {
+				if (entry) entry.handle = handle;
+			},
 		},
 	);
+	void lifecycle.catch(() => undefined).finally(() => {
+		forgetLedgerOverlay(entry);
+	});
+	await Promise.resolve();
 	return supported;
 }
 
 export function showContinuationLedgerOverlaySoon(
 	ctx: ExtensionContext,
 	ledger: ContinuationLedgerSnapshot,
+	singleOverlay: boolean,
 	onError: (reason: string) => void,
 ): void {
-	void showContinuationLedgerOverlay(ctx, ledger)
+	void showContinuationLedgerOverlay(ctx, ledger, singleOverlay)
 		.then((shown) => {
 			if (!shown) onError("Continuation Ledger cannot open in this Pi mode.");
 		})
@@ -96,16 +148,13 @@ export function showContinuationLedgerOverlaySoon(
 export async function showLatestContinuationLedger(
 	ctx: ExtensionCommandContext,
 	ledger: ContinuationLedgerSnapshot | undefined,
+	singleOverlay = true,
 ): Promise<void> {
 	if (!ledger) {
 		if (ctx.hasUI) ctx.ui.notify("No Continuation Ledger has been created in this session yet.", "warning");
 		return;
 	}
-	const shown = await showScrollableTextOverlay(ctx, {
-		title: "Continuation Ledger",
-		content: ledger.content,
-		headerLines: ledgerHeaderLines(ledger),
-	});
+	const shown = await showContinuationLedgerOverlay(ctx, ledger, singleOverlay);
 	if (!shown && ctx.hasUI) {
 		ctx.ui.notify("Continuation Ledger cannot open in this Pi mode.", "warning");
 	}

--- a/extensions/continue/src/ledger-viewer.ts
+++ b/extensions/continue/src/ledger-viewer.ts
@@ -16,6 +16,8 @@ interface LedgerOverlayHandle {
 interface TrackedLedgerOverlay {
 	overlay: ContinuationLedgerOverlay;
 	handle: LedgerOverlayHandle | undefined;
+	closedByUser: boolean;
+	closeRequested: boolean;
 }
 
 const openLedgerOverlays = new Set<TrackedLedgerOverlay>();
@@ -59,9 +61,13 @@ function forgetLedgerOverlay(entry: TrackedLedgerOverlay | undefined): void {
 
 export function closeContinuationLedgerOverlays(): void {
 	const open = [...openLedgerOverlays];
-	openLedgerOverlays.clear();
-	activeLedgerOverlay = undefined;
-	for (const entry of open.reverse()) entry.handle?.hide();
+	for (const entry of open) {
+		if (!entry.closedByUser) entry.closeRequested = true;
+		forgetLedgerOverlay(entry);
+	}
+	for (const entry of open.filter((entry) => !entry.closedByUser).reverse()) {
+		entry.handle?.hide();
+	}
 }
 
 export function clearContinuationLedgerOverlay(): void {
@@ -103,8 +109,11 @@ export async function showContinuationLedgerOverlay(
 	const lifecycle = ctx.ui.custom<void>(
 		(tui, theme, _keybindings, done) => {
 			supported = true;
-			const overlay = new ContinuationLedgerOverlay(ledger, theme, () => done(), () => tui.requestRender());
-			entry = { overlay, handle: undefined };
+			const overlay = new ContinuationLedgerOverlay(ledger, theme, () => {
+				if (entry) entry.closedByUser = true;
+				done();
+			}, () => tui.requestRender());
+			entry = { overlay, handle: undefined, closedByUser: false, closeRequested: false };
 			openLedgerOverlays.add(entry);
 			if (singleOverlay) activeLedgerOverlay = entry;
 			return overlay;
@@ -119,7 +128,10 @@ export async function showContinuationLedgerOverlay(
 				margin: 1,
 			},
 			onHandle: (handle) => {
-				if (entry) entry.handle = handle;
+				if (entry) {
+					entry.handle = handle;
+					if (entry.closeRequested) handle.hide();
+				}
 			},
 		},
 	);

--- a/extensions/continue/src/status.ts
+++ b/extensions/continue/src/status.ts
@@ -278,6 +278,7 @@ export function renderStatus(
 		`- Prompt override policy: ${config.promptOverridePolicy}`,
 		`- Show brief after compaction: ${config.showAfterCompact ? "yes" : "no"}`,
 		`- Single Ledger overlay: ${config.singleLedgerOverlay ? "yes" : "no"}`,
+		`- Auto-close Ledger overlays: ${config.ledgerOverlayAutoClose}`,
 		``,
 		`## Pi Core Compaction`,
 		`- Enabled: ${piCompactionSettings.enabled ? "yes" : "no"}`,

--- a/extensions/continue/src/status.ts
+++ b/extensions/continue/src/status.ts
@@ -277,6 +277,7 @@ export function renderStatus(
 		`- Append modified file tags: ${config.appendModifiedFileTags ? "yes" : "no"}`,
 		`- Prompt override policy: ${config.promptOverridePolicy}`,
 		`- Show brief after compaction: ${config.showAfterCompact ? "yes" : "no"}`,
+		`- Single Ledger overlay: ${config.singleLedgerOverlay ? "yes" : "no"}`,
 		``,
 		`## Pi Core Compaction`,
 		`- Enabled: ${piCompactionSettings.enabled ? "yes" : "no"}`,

--- a/extensions/continue/src/text-viewer.ts
+++ b/extensions/continue/src/text-viewer.ts
@@ -130,10 +130,10 @@ export class ScrollableTextOverlay {
 	private scroll = 0;
 	private cachedWidth: number | undefined;
 	private cachedLines: string[] | undefined;
-	private readonly title: string;
-	private readonly content: string;
-	private readonly headerLines: string[];
-	private readonly footer: string;
+	private title: string;
+	private content: string;
+	private headerLines: string[];
+	private footer: string;
 	private readonly theme: ViewerTheme;
 	private readonly done: () => void;
 	private readonly requestRender: () => void;
@@ -151,6 +151,16 @@ export class ScrollableTextOverlay {
 		this.theme = theme;
 		this.done = done;
 		this.requestRender = requestRender;
+	}
+
+	update(options: ScrollableTextOverlayOptions): void {
+		this.title = sanitizeOverlayText(options.title).trim() || "Preview";
+		this.content = sanitizeOverlayText(options.content);
+		this.headerLines = (options.headerLines ?? []).map((line) => sanitizeOverlayText(line));
+		this.footer = options.footer ?? "↑↓/j/k scroll | PgUp/PgDn page | Enter/q/Esc close";
+		this.scroll = 0;
+		this.invalidate();
+		this.requestRender();
 	}
 
 	handleInput(data: string): void {

--- a/extensions/continue/src/types.ts
+++ b/extensions/continue/src/types.ts
@@ -26,6 +26,7 @@ export interface ContinuationConfig {
 	appendModifiedFileTags: boolean;
 	promptOverridePolicy: PromptOverridePolicy;
 	showAfterCompact: boolean;
+	singleLedgerOverlay: boolean;
 }
 
 export interface ResolvedProjectContext {

--- a/extensions/continue/src/types.ts
+++ b/extensions/continue/src/types.ts
@@ -8,6 +8,7 @@ export type ContinuationReasoning =
 	| "xhigh";
 
 export type PromptOverridePolicy = "package-default" | "global-override" | "project-override";
+export type LedgerOverlayAutoClose = "disabled" | "completed" | "all";
 export type WriteMode = "always" | "off";
 export type ConfigScope = "global" | "project";
 export type HistoryScenario = "initial" | "update";
@@ -27,6 +28,7 @@ export interface ContinuationConfig {
 	promptOverridePolicy: PromptOverridePolicy;
 	showAfterCompact: boolean;
 	singleLedgerOverlay: boolean;
+	ledgerOverlayAutoClose: LedgerOverlayAutoClose;
 }
 
 export interface ResolvedProjectContext {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -41,27 +41,37 @@ test("loadContinuationConfig uses current-session model, reasoning, guard, and o
 		assert.equal(config.appendReadFileTags, false);
 		assert.equal(config.appendModifiedFileTags, true);
 		assert.equal(config.showAfterCompact, true);
+		assert.equal(config.singleLedgerOverlay, true);
 	});
 });
 
-test("loadContinuationConfig ignores non-boolean showAfterCompact", async () => {
+test("loadContinuationConfig ignores non-boolean overlay settings", async () => {
 	await withTempAgent(async (root) => {
 		const configDir = join(root, ".pi", "extensions");
 		mkdirSync(configDir, { recursive: true });
-		writeFileSync(join(configDir, "pi-continue.json"), JSON.stringify({ showAfterCompact: "yes" }), "utf8");
+		writeFileSync(join(configDir, "pi-continue.json"), JSON.stringify({
+			showAfterCompact: "yes",
+			singleLedgerOverlay: "no",
+		}), "utf8");
 		const config = loadContinuationConfig(root);
 		assert.equal(config.showAfterCompact, true);
+		assert.equal(config.singleLedgerOverlay, true);
 	});
 });
 
-test("loadContinuationConfig preserves explicit mid-run guard false", async () => {
+test("loadContinuationConfig preserves explicit overlay setting false", async () => {
 	await withTempAgent(async (root) => {
 		const configDir = join(root, ".pi", "extensions");
 		mkdirSync(configDir, { recursive: true });
-		writeFileSync(join(configDir, "pi-continue.json"), JSON.stringify({ midRunGuardEnabled: false, showAfterCompact: false }), "utf8");
+		writeFileSync(join(configDir, "pi-continue.json"), JSON.stringify({
+			midRunGuardEnabled: false,
+			showAfterCompact: false,
+			singleLedgerOverlay: false,
+		}), "utf8");
 		const config = loadContinuationConfig(root);
 		assert.equal(config.midRunGuardEnabled, false);
 		assert.equal(config.showAfterCompact, false);
+		assert.equal(config.singleLedgerOverlay, false);
 	});
 });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -42,24 +42,27 @@ test("loadContinuationConfig uses current-session model, reasoning, guard, and o
 		assert.equal(config.appendModifiedFileTags, true);
 		assert.equal(config.showAfterCompact, true);
 		assert.equal(config.singleLedgerOverlay, true);
+		assert.equal(config.ledgerOverlayAutoClose, "disabled");
 	});
 });
 
-test("loadContinuationConfig ignores non-boolean overlay settings", async () => {
+test("loadContinuationConfig ignores invalid overlay settings", async () => {
 	await withTempAgent(async (root) => {
 		const configDir = join(root, ".pi", "extensions");
 		mkdirSync(configDir, { recursive: true });
 		writeFileSync(join(configDir, "pi-continue.json"), JSON.stringify({
 			showAfterCompact: "yes",
 			singleLedgerOverlay: "no",
+			ledgerOverlayAutoClose: "never",
 		}), "utf8");
 		const config = loadContinuationConfig(root);
 		assert.equal(config.showAfterCompact, true);
 		assert.equal(config.singleLedgerOverlay, true);
+		assert.equal(config.ledgerOverlayAutoClose, "disabled");
 	});
 });
 
-test("loadContinuationConfig preserves explicit overlay setting false", async () => {
+test("loadContinuationConfig preserves explicit overlay settings", async () => {
 	await withTempAgent(async (root) => {
 		const configDir = join(root, ".pi", "extensions");
 		mkdirSync(configDir, { recursive: true });
@@ -67,11 +70,13 @@ test("loadContinuationConfig preserves explicit overlay setting false", async ()
 			midRunGuardEnabled: false,
 			showAfterCompact: false,
 			singleLedgerOverlay: false,
+			ledgerOverlayAutoClose: "all",
 		}), "utf8");
 		const config = loadContinuationConfig(root);
 		assert.equal(config.midRunGuardEnabled, false);
 		assert.equal(config.showAfterCompact, false);
 		assert.equal(config.singleLedgerOverlay, false);
+		assert.equal(config.ledgerOverlayAutoClose, "all");
 	});
 });
 

--- a/tests/index-extension.test.ts
+++ b/tests/index-extension.test.ts
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import registerContinueExtension from "../extensions/continue/index.ts";
+import { clearContinuationLedgerOverlay } from "../extensions/continue/src/ledger-viewer.ts";
 import { buildContinuationArtifactPath } from "../extensions/continue/src/project.ts";
 import { CONTINUATION_PROMPT } from "../extensions/continue/src/runtime.ts";
 import { NO_PRE_COMPACTION_MESSAGES_KEPT_ENTRY_ID } from "../extensions/continue/src/compaction-preparation.ts";
@@ -178,6 +179,14 @@ function writeArtifactOffConfig(cwd) {
 	mkdirSync(join(cwd, ".pi", "extensions"), { recursive: true });
 	writeFileSync(join(cwd, ".pi", "extensions", "pi-continue.json"), JSON.stringify({
 		continuationArtifactMode: "off",
+	}), "utf8");
+}
+
+function writeLedgerAutoCloseConfig(cwd, ledgerOverlayAutoClose, extra = {}) {
+	mkdirSync(join(cwd, ".pi", "extensions"), { recursive: true });
+	writeFileSync(join(cwd, ".pi", "extensions", "pi-continue.json"), JSON.stringify({
+		ledgerOverlayAutoClose,
+		...extra,
 	}), "utf8");
 }
 
@@ -531,6 +540,209 @@ test("message_end settles failed and aborted resume outcomes without footer stat
 	await abortedPi.events.get("message_end")({ message: assistantMessage("aborted") }, abortedCtx);
 	assert.deepEqual(abortedCtx.statusCalls, []);
 	assert.equal(abortedCtx.workingMessages.at(-1), undefined);
+});
+
+function createOverlayTrackingContext(cwd, options) {
+	let hideCalls = 0;
+	const asyncHandle = options?.asyncHandle ?? false;
+	const ctx = createCommandContext(cwd, async (factory, uiOptions) => {
+		factory({ requestRender() {} }, ctx.ui.theme, {}, () => {});
+		const handle = { focus() {}, hide() { hideCalls += 1; } };
+		if (asyncHandle) {
+			await Promise.resolve();
+			uiOptions.onHandle(handle);
+			return new Promise(() => {});
+		}
+		uiOptions.onHandle(handle);
+		return new Promise(() => {});
+	});
+	return { ctx, hideCalls: () => hideCalls };
+}
+
+async function runContinuationWithOverlay(cwd, stopReason, ledgerOverlayAutoClose) {
+	writeLedgerAutoCloseConfig(cwd, ledgerOverlayAutoClose);
+	const pi = createFakePi(cwd);
+	const overlay = createOverlayTrackingContext(cwd);
+	registerContinueExtension(pi);
+	await pi.commands.get("continue").handler("steer", overlay.ctx);
+	overlay.ctx.compactOptions.onComplete({});
+	await pi.events.get("session_compact")(ownedCompactionEvent(), overlay.ctx);
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	await pi.events.get("before_agent_start")({ prompt: CONTINUATION_PROMPT }, overlay.ctx);
+	await pi.events.get("message_end")({ message: assistantMessage(stopReason) }, overlay.ctx);
+	const result = overlay.hideCalls();
+	clearContinuationLedgerOverlay();
+	return result;
+}
+
+test("ledgerOverlayAutoClose is disabled by default", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-autoclose-default-"));
+	try {
+		const pi = createFakePi(cwd);
+		let hideCalls = 0;
+		const ctx = createCommandContext(cwd, async (factory, options) => {
+			factory({ requestRender() {} }, ctx.ui.theme, {}, () => {});
+			options.onHandle({ focus() {}, hide() { hideCalls += 1; } });
+			return new Promise(() => {});
+		});
+		registerContinueExtension(pi);
+		await pi.commands.get("continue").handler("steer", ctx);
+		ctx.compactOptions.onComplete({});
+		await pi.events.get("session_compact")(ownedCompactionEvent(), ctx);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await pi.events.get("before_agent_start")({ prompt: CONTINUATION_PROMPT }, ctx);
+		await pi.events.get("message_end")({ message: assistantMessage("stop") }, ctx);
+		assert.equal(hideCalls, 0);
+		clearContinuationLedgerOverlay();
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("ledgerOverlayAutoClose completed only closes successful resumes", async () => {
+	const completedCwd = mkdtempSync(join(tmpdir(), "pi-continue-autoclose-completed-"));
+	const failedCwd = mkdtempSync(join(tmpdir(), "pi-continue-autoclose-failed-"));
+	try {
+		assert.equal(await runContinuationWithOverlay(completedCwd, "stop", "completed"), 1);
+		assert.equal(await runContinuationWithOverlay(failedCwd, "length", "completed"), 0);
+	} finally {
+		rmSync(completedCwd, { recursive: true, force: true });
+		rmSync(failedCwd, { recursive: true, force: true });
+	}
+});
+
+test("ledgerOverlayAutoClose all closes failed and aborted resumes", async () => {
+	for (const stopReason of ["length", "aborted"]) {
+		const cwd = mkdtempSync(join(tmpdir(), `pi-continue-autoclose-${stopReason}-`));
+		try {
+			assert.equal(await runContinuationWithOverlay(cwd, stopReason, "all"), 1);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	}
+});
+
+test("ledgerOverlayAutoClose all closes resumes that end without an assistant response", async () => {
+	for (const [policy, expectedHideCalls] of [["all", 1], ["completed", 0]]) {
+		const cwd = mkdtempSync(join(tmpdir(), `pi-continue-autoclose-agent-end-${policy}-`));
+		try {
+			writeLedgerAutoCloseConfig(cwd, policy);
+			const pi = createFakePi(cwd);
+			const overlay = createOverlayTrackingContext(cwd);
+			registerContinueExtension(pi);
+			await pi.commands.get("continue").handler("steer", overlay.ctx);
+			overlay.ctx.compactOptions.onComplete({});
+			await pi.events.get("session_compact")(ownedCompactionEvent(), overlay.ctx);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			await pi.events.get("before_agent_start")({ prompt: CONTINUATION_PROMPT }, overlay.ctx);
+			await pi.events.get("agent_end")({}, overlay.ctx);
+			assert.equal(overlay.hideCalls(), expectedHideCalls);
+		} finally {
+			clearContinuationLedgerOverlay();
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	}
+});
+
+test("ledgerOverlayAutoClose all closes when resume prompt dispatch fails", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-autoclose-dispatch-fail-"));
+	try {
+		writeLedgerAutoCloseConfig(cwd, "all");
+		const pi = createFakePi(cwd);
+		pi.sendUserMessage = () => {
+			throw new Error("dispatch failed");
+		};
+		const overlay = createOverlayTrackingContext(cwd);
+		registerContinueExtension(pi);
+		await pi.commands.get("continue").handler("steer", overlay.ctx);
+		overlay.ctx.compactOptions.onComplete({});
+		await pi.events.get("session_compact")(ownedCompactionEvent(), overlay.ctx);
+		assert.deepEqual(pi.sent, []);
+		assert.equal(overlay.hideCalls(), 1);
+	} finally {
+		clearContinuationLedgerOverlay();
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("ledgerOverlayAutoClose all closes dispatch failures even when overlay handle arrives asynchronously", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-autoclose-dispatch-fail-async-handle-"));
+	try {
+		writeLedgerAutoCloseConfig(cwd, "all");
+		const pi = createFakePi(cwd);
+		pi.sendUserMessage = () => {
+			throw new Error("dispatch failed");
+		};
+		const overlay = createOverlayTrackingContext(cwd, { asyncHandle: true });
+		registerContinueExtension(pi);
+		await pi.commands.get("continue").handler("steer", overlay.ctx);
+		overlay.ctx.compactOptions.onComplete({});
+		await pi.events.get("session_compact")(ownedCompactionEvent(), overlay.ctx);
+		assert.deepEqual(pi.sent, []);
+		await Promise.resolve();
+		assert.equal(overlay.hideCalls(), 1);
+	} finally {
+		clearContinuationLedgerOverlay();
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("ledgerOverlayAutoClose all closes when a sent resume never starts", async (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-autoclose-start-timeout-"));
+	try {
+		writeLedgerAutoCloseConfig(cwd, "all");
+		const pi = createFakePi(cwd);
+		const overlay = createOverlayTrackingContext(cwd);
+		registerContinueExtension(pi);
+		await pi.commands.get("continue").handler("steer", overlay.ctx);
+		overlay.ctx.compactOptions.onComplete({});
+		await pi.events.get("session_compact")(ownedCompactionEvent(), overlay.ctx);
+		assert.equal(overlay.hideCalls(), 0);
+		t.mock.timers.tick(30_000);
+		assert.equal(overlay.hideCalls(), 1);
+	} finally {
+		clearContinuationLedgerOverlay();
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("ledgerOverlayAutoClose all closes stacked legacy Ledger overlays", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-autoclose-stacked-"));
+	try {
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		writeFileSync(join(cwd, ".pi", "settings.json"), JSON.stringify({
+			compaction: { enabled: true, reserveTokens: 20, keepRecentTokens: 10 },
+		}), "utf8");
+		writeLedgerAutoCloseConfig(cwd, "all", { singleLedgerOverlay: false });
+		const pi = createFakePi(cwd);
+		const hidden = [];
+		const ctx = createCommandContext(cwd, async (factory, options) => {
+			const component = factory({ requestRender() {} }, ctx.ui.theme, {}, () => {});
+			options.onHandle({ focus() {}, hide() { hidden.push(component.render(80).join("\n")); } });
+			return new Promise(() => {});
+		});
+		ctx.model = { ...ctx.model, contextWindow: 100 };
+		registerContinueExtension(pi);
+		await pi.commands.get("continue").handler("steer", ctx);
+		ctx.compactOptions.onComplete({});
+		await pi.events.get("session_compact")(ownedCompactionEvent(), ctx);
+		await pi.events.get("before_agent_start")({ prompt: CONTINUATION_PROMPT }, ctx);
+		await pi.events.get("message_end")({ message: highUsageAssistantMessage() }, ctx);
+		await pi.events.get("context")({
+			messages: [userMessage("continue tools"), highUsageAssistantMessage(), toolResultMessage("x".repeat(160))],
+		}, ctx);
+		ctx.compactOptions.onComplete({});
+		await pi.events.get("session_compact")(ownedCompactionEvent("continue-2"), ctx);
+		await pi.events.get("before_agent_start")({ prompt: CONTINUATION_PROMPT }, ctx);
+		await pi.events.get("message_end")({ message: assistantMessage("stop") }, ctx);
+		assert.equal(hidden.length, 2);
+		assert.match(hidden[0], /ledger body/);
+		assert.match(hidden[1], /ledger body/);
+	} finally {
+		clearContinuationLedgerOverlay();
+		rmSync(cwd, { recursive: true, force: true });
+	}
 });
 
 test("session_compact native or invalid active handoff proof fails closed without resume", async () => {

--- a/tests/ledger-viewer.test.ts
+++ b/tests/ledger-viewer.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildLedgerSnapshot, ContinuationLedgerOverlay, extractContinuationLedger, showContinuationLedgerOverlay } from "../extensions/continue/src/ledger-viewer.ts";
+import { buildLedgerSnapshot, clearContinuationLedgerOverlay, ContinuationLedgerOverlay, extractContinuationLedger, showContinuationLedgerOverlay } from "../extensions/continue/src/ledger-viewer.ts";
 
 const theme = {
 	fg(_color, text) {
@@ -48,13 +48,14 @@ test("showContinuationLedgerOverlay reports unsupported custom UI", async () => 
 		{
 			hasUI: true,
 			ui: {
-				async custom(factory) {
+				async custom(_factory) {
 					factoryInvoked = false;
 					return undefined;
 				},
 			},
 		},
 		{ eventId: "continue-1", compactionEntryId: "compact-1", content: "ledger", capturedAt: 0 },
+		true,
 	);
 	assert.equal(factoryInvoked, false);
 	assert.equal(shown, false);
@@ -74,9 +75,57 @@ test("showContinuationLedgerOverlay reports supported custom UI", async () => {
 			},
 		},
 		{ eventId: "continue-1", compactionEntryId: "compact-1", content: "ledger", capturedAt: 0 },
+		true,
 	);
+	clearContinuationLedgerOverlay();
 	assert.equal(factoryInvoked, true);
 	assert.equal(shown, true);
+});
+
+test("showContinuationLedgerOverlay updates and focuses the active singleton", async () => {
+	let customCalls = 0;
+	let focusCalls = 0;
+	let requestRenders = 0;
+	let resolveOverlay: (() => void) | undefined;
+	const ctx = {
+		hasUI: true,
+		ui: {
+			custom(factory, options) {
+				customCalls += 1;
+				factory({ requestRender() { requestRenders += 1; } }, theme, {}, () => {});
+				options.onHandle({ focus() { focusCalls += 1; }, hide() {} });
+				return new Promise<void>((resolve) => {
+					resolveOverlay = resolve;
+				});
+			},
+		},
+	};
+	const first = showContinuationLedgerOverlay(ctx, { eventId: "continue-1", compactionEntryId: "compact-1", content: "first", capturedAt: 0 }, true);
+	await Promise.resolve();
+	assert.equal(await showContinuationLedgerOverlay(ctx, { eventId: "continue-2", compactionEntryId: "compact-2", content: "second", capturedAt: 1 }, true), true);
+	assert.equal(customCalls, 1);
+	assert.equal(focusCalls, 1);
+	assert.equal(requestRenders, 1);
+	clearContinuationLedgerOverlay();
+	resolveOverlay?.();
+	assert.equal(await first, true);
+});
+
+test("showContinuationLedgerOverlay can keep backward-compatible stacked overlays", async () => {
+	let customCalls = 0;
+	const ctx = {
+		hasUI: true,
+		ui: {
+			async custom(factory) {
+				customCalls += 1;
+				factory({ requestRender() {} }, theme, {}, () => {});
+				return undefined;
+			},
+		},
+	};
+	assert.equal(await showContinuationLedgerOverlay(ctx, { eventId: "continue-1", compactionEntryId: "compact-1", content: "first", capturedAt: 0 }, false), true);
+	assert.equal(await showContinuationLedgerOverlay(ctx, { eventId: "continue-2", compactionEntryId: "compact-2", content: "second", capturedAt: 1 }, false), true);
+	assert.equal(customCalls, 2);
 });
 
 test("ContinuationLedgerOverlay renders scrollable ledger panel", () => {
@@ -100,4 +149,23 @@ test("ContinuationLedgerOverlay renders scrollable ledger panel", () => {
 	overlay.handleInput("q");
 	assert.equal(closed, true);
 	assert.equal(renders, 0);
+});
+
+test("ContinuationLedgerOverlay updates content in place", () => {
+	let renders = 0;
+	const overlay = new ContinuationLedgerOverlay(
+		{ eventId: "continue-1", compactionEntryId: "compact-1", content: "first", capturedAt: 0 },
+		theme,
+		() => {},
+		() => {
+			renders += 1;
+		},
+	);
+	overlay.handleInput("down");
+	overlay.setLedger({ eventId: "continue-2", compactionEntryId: "compact-2", content: "second", capturedAt: 1 });
+	const text = overlay.render(80).join("\n");
+	assert.match(text, /run continue-2 \| compaction compact-2/);
+	assert.match(text, /second/);
+	assert.doesNotMatch(text, /first/);
+	assert.equal(renders, 1);
 });

--- a/tests/ledger-viewer.test.ts
+++ b/tests/ledger-viewer.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildLedgerSnapshot, clearContinuationLedgerOverlay, ContinuationLedgerOverlay, extractContinuationLedger, showContinuationLedgerOverlay } from "../extensions/continue/src/ledger-viewer.ts";
+import { buildLedgerSnapshot, clearContinuationLedgerOverlay, closeContinuationLedgerOverlays, ContinuationLedgerOverlay, extractContinuationLedger, showContinuationLedgerOverlay } from "../extensions/continue/src/ledger-viewer.ts";
 
 const theme = {
 	fg(_color, text) {
@@ -126,6 +126,48 @@ test("showContinuationLedgerOverlay can keep backward-compatible stacked overlay
 	assert.equal(await showContinuationLedgerOverlay(ctx, { eventId: "continue-1", compactionEntryId: "compact-1", content: "first", capturedAt: 0 }, false), true);
 	assert.equal(await showContinuationLedgerOverlay(ctx, { eventId: "continue-2", compactionEntryId: "compact-2", content: "second", capturedAt: 1 }, false), true);
 	assert.equal(customCalls, 2);
+	clearContinuationLedgerOverlay();
+});
+
+test("closeContinuationLedgerOverlays closes all uncancelled stacked overlays", async () => {
+	const hidden: string[] = [];
+	const ctx = {
+		hasUI: true,
+		ui: {
+			custom(factory, options) {
+				const component = factory({ requestRender() {} }, theme, {}, () => {});
+				options.onHandle({ focus() {}, hide() { hidden.push(component.render(80).join("\n")); } });
+				return new Promise<void>(() => {});
+			},
+		},
+	};
+	assert.equal(await showContinuationLedgerOverlay(ctx, { eventId: "continue-1", compactionEntryId: "compact-1", content: "first", capturedAt: 0 }, false), true);
+	assert.equal(await showContinuationLedgerOverlay(ctx, { eventId: "continue-2", compactionEntryId: "compact-2", content: "second", capturedAt: 1 }, false), true);
+	closeContinuationLedgerOverlays();
+	assert.equal(hidden.length, 2);
+	assert.match(hidden[0], /second/);
+	assert.match(hidden[1], /first/);
+});
+
+test("closeContinuationLedgerOverlays leaves user-cancelled overlays alone", async () => {
+	let component;
+	let hideCalls = 0;
+	const ctx = {
+		hasUI: true,
+		ui: {
+			custom(factory, options) {
+				component = factory({ requestRender() {} }, theme, {}, () => {});
+				options.onHandle({ focus() {}, hide() { hideCalls += 1; } });
+				return new Promise<void>(() => {});
+			},
+		},
+	};
+	const shown = await showContinuationLedgerOverlay(ctx, { eventId: "continue-1", compactionEntryId: "compact-1", content: "first", capturedAt: 0 }, true);
+	assert.equal(shown, true);
+	component.handleInput("q");
+	closeContinuationLedgerOverlays();
+	assert.equal(hideCalls, 0);
+	clearContinuationLedgerOverlay();
 });
 
 test("ContinuationLedgerOverlay renders scrollable ledger panel", () => {

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -59,6 +59,7 @@ test("renderStatus reports local runtime wiring and artifact behavior", () => {
 		assert.match(rendered, /full agentGuideUpdate\.content replacements/);
 		assert.match(rendered, /- Append read file tags: no/);
 		assert.match(rendered, /- Append modified file tags: yes/);
+		assert.match(rendered, /- Auto-close Ledger overlays: disabled/);
 		assert.match(rendered, /Brief entries guide the receiver; they are not proof that files were written/);
 		assert.match(rendered, /- Scenario: unavailable/);
 	} finally {


### PR DESCRIPTION
## Summary
- add `singleLedgerOverlay` (default `true`) so package-owned Continuation Ledger panels update and refocus instead of stacking after each compaction
- add `ledgerOverlayAutoClose` (default `"disabled"`) with `"completed"` and `"all"` modes to close package-owned Ledger panels after continuation resumes settle
- keep the legacy stacked-panel mode available with `singleLedgerOverlay: false`, including auto-closing all tracked stacked overlays when enabled

## Testing
- Not run after the latest fork push by the branch author. Earlier local validation before the latest push: `pnpm run gate`
