### PR TITLE
fix(continue): show inactive overlay focus state

### DIFF
--- a/extensions/continue/src/text-viewer.ts
+++ b/extensions/continue/src/text-viewer.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Focusable } from "@earendil-works/pi-tui";
 import { padVisible, stripAnsi, truncateAnsi, visibleWidth } from "./tui-text.ts";
 
 const MIN_WIDTH = 48;
@@ -38,21 +39,29 @@ export function sanitizeOverlayText(content: string): string {
 		.replace(ESCAPE_CHARACTER_PATTERN, "");
 }
 
-function topLine(theme: ViewerTheme, width: number, title: string): string {
+function borderColor(focused: boolean): ViewerColor {
+	return focused ? "border" : "muted";
+}
+
+function titleColor(focused: boolean): ViewerColor {
+	return focused ? "accent" : "dim";
+}
+
+function topLine(theme: ViewerTheme, width: number, title: string, focused: boolean): string {
 	const label = ` ${title} `;
 	const fill = Math.max(0, width - visibleWidth(label) - 2);
-	return `${theme.fg("border", "+")}${theme.fg("accent", label)}${theme.fg("border", `${"-".repeat(fill)}+`)}`;
+	return `${theme.fg(borderColor(focused), "+")}${theme.fg(titleColor(focused), label)}${theme.fg(borderColor(focused), `${"-".repeat(fill)}+`)}`;
 }
 
-function bottomLine(theme: ViewerTheme, width: number): string {
+function bottomLine(theme: ViewerTheme, width: number, focused: boolean): string {
 	const inner = Math.max(0, width - 2);
-	return theme.fg("border", `+${"-".repeat(inner)}+`);
+	return theme.fg(borderColor(focused), `+${"-".repeat(inner)}+`);
 }
 
-function frame(theme: ViewerTheme, width: number, content: string): string {
+function frame(theme: ViewerTheme, width: number, content: string, focused: boolean): string {
 	const inner = Math.max(0, width - 2);
 	const safe = padVisible(truncateAnsi(content, inner), inner);
-	return `${theme.fg("border", "|")}${safe}${theme.fg("border", "|")}`;
+	return `${theme.fg(borderColor(focused), "|")}${safe}${theme.fg(borderColor(focused), "|")}`;
 }
 
 function wrapPlainLine(line: string, width: number): string[] {
@@ -126,7 +135,8 @@ function keyRepeat(data: string, key: "up" | "down" | "page-up" | "page-down" | 
 	return repeatCount(data, ["enter", "return", "\r", "\n", "escape", "q", "\u001b", "ctrl+c", "\u0003"]);
 }
 
-export class ScrollableTextOverlay {
+export class ScrollableTextOverlay implements Focusable {
+	focused = false;
 	private scroll = 0;
 	private cachedWidth: number | undefined;
 	private cachedLines: string[] | undefined;
@@ -186,15 +196,18 @@ export class ScrollableTextOverlay {
 		const scrollLabel = content.length > page
 			? `lines ${this.scroll + 1}-${Math.min(content.length, this.scroll + page)} of ${content.length}`
 			: `${content.length} lines`;
+		const footer = this.focused
+			? this.footer
+			: "Not focused: check to regain focus";
 		return [
-			topLine(this.theme, overlayWidth, this.title),
-			...this.headerLines.map((line) => frame(this.theme, overlayWidth, ` ${this.theme.fg("dim", line)}`)),
-			frame(this.theme, overlayWidth, ` ${this.theme.fg("dim", scrollLabel)}`),
-			frame(this.theme, overlayWidth, ""),
-			...visible.map((line) => frame(this.theme, overlayWidth, ` ${line}`)),
-			frame(this.theme, overlayWidth, ""),
-			frame(this.theme, overlayWidth, ` ${this.theme.fg("dim", this.footer)}`),
-			bottomLine(this.theme, overlayWidth),
+			topLine(this.theme, overlayWidth, this.title, this.focused),
+			...this.headerLines.map((line) => frame(this.theme, overlayWidth, ` ${this.theme.fg("dim", line)}`, this.focused)),
+			frame(this.theme, overlayWidth, ` ${this.theme.fg("dim", scrollLabel)}`, this.focused),
+			frame(this.theme, overlayWidth, "", this.focused),
+			...visible.map((line) => frame(this.theme, overlayWidth, ` ${line}`, this.focused)),
+			frame(this.theme, overlayWidth, "", this.focused),
+			frame(this.theme, overlayWidth, ` ${this.theme.fg("dim", footer)}`, this.focused),
+			bottomLine(this.theme, overlayWidth, this.focused),
 		];
 	}
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.74.0",
-    "@earendil-works/pi-coding-agent": ">=0.74.0"
+    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-tui": ">=0.74.0"
   },
   "pi": {
     "extensions": [
@@ -56,6 +57,7 @@
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.74.0",
     "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
     "@types/node": "^25.6.1",
     "typescript": "^6.0.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: ^0.74.0
         version: 0.74.0(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: ^0.74.0
+        version: 0.74.0
       '@types/node':
         specifier: ^25.6.1
         version: 25.6.1

--- a/tests/text-viewer.test.ts
+++ b/tests/text-viewer.test.ts
@@ -11,6 +11,21 @@ const theme = {
 	},
 };
 
+const colorTheme = {
+	fg(color, text) {
+		const code = {
+			accent: "\u001b[36m",
+			border: "\u001b[34m",
+			dim: "\u001b[2m",
+			muted: "\u001b[90m",
+		}[color];
+		return `${code}${text}\u001b[0m`;
+	},
+	bold(text) {
+		return text;
+	},
+};
+
 function renderedBody(overlay) {
 	return overlay.render(80).join("\n");
 }
@@ -20,6 +35,24 @@ test("sanitizeOverlayText strips terminal controls", () => {
 		sanitizeOverlayText("\u001b]2;title\u0007\u001b[31mred\u001b[0m\r\nline\u0000two"),
 		"red\nlinetwo",
 	);
+});
+
+test("ScrollableTextOverlay dims border and explains when focus is elsewhere", () => {
+	const overlay = new ScrollableTextOverlay(
+		{ title: "preview", content: "body" },
+		colorTheme,
+		() => {},
+		() => {},
+	);
+	const unfocused = renderedBody(overlay);
+	assert.match(unfocused, /\u001b\[90m\+\u001b\[0m/);
+	assert.match(unfocused, /Not focused: check to regain focus/);
+
+	overlay.focused = true;
+	const focused = renderedBody(overlay);
+	assert.match(focused, /\u001b\[34m\+\u001b\[0m/);
+	assert.match(focused, /Enter\/q\/Esc close/);
+	assert.doesNotMatch(focused, /Not focused:/);
 });
 
 test("ScrollableTextOverlay scrolls repeated held-arrow chunks", () => {


### PR DESCRIPTION
## Summary
- make ScrollableTextOverlay focus-aware via Pi TUI Focusable
- render muted inactive borders and the footer \`Not focused: check to regain focus\` when another prompt/plugin owns focus
- keep the normal scroll/close shortcut footer while focused

## Validation
- \`node --experimental-strip-types --test tests/text-viewer.test.ts\`
- \`PI_CODING_AGENT_DIR=\"$(mktemp -d)\" pnpm run gate\` (temporary agent dir)