### PR TITLE
[codex] Integrate TUI input and Ledger overlay cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `pi-continue` are documented here.
 
 ## Unreleased
 
+### Changed
+
+- Reused the current Continuation Ledger TUI panel when a new ledger is shown, so repeated automatic displays and `/continue ledger` update and focus the latest handoff instead of stacking panels.
+- Switched continuation palette and text-overlay keyboard handling to Pi TUI key matching for Kitty/CSI-u input; text overlays also use Pi TUI event buffering for repeated key events.
+
+### Fixed
+
+- Allowed CSI-u Escape/Enter and key-identity shortcuts to close overlays and open `/continue` focus notes reliably, including layouts where the physical `f` shortcut does not decode as printable `f`.
+- Added inactive overlay focus copy and dimmed chrome so users can tell when another panel owns keyboard focus.
+
 ## 0.8.2 - 2026-05-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Configure the threshold directly in Pi settings, or choose `Handoff trigger` in 
 
 `reserveTokens` and `keepRecentTokens` are absolute token counts. For a 272K context model, an explicit `reserveTokens: 68000` triggers near 75 percent usage. The `/continue settings` control shows and edits the human trigger token count, then saves Pi's canonical `compaction.reserveTokens` value at the selected settings scope; the trigger is not stored in `pi-continue.json`. See [`examples/pi-settings-compaction-75pct-272k.json`](examples/pi-settings-compaction-75pct-272k.json).
 
-Use `/continue status` after a continuation to see what happened. Status reports the latest local run: how the handoff started, whether the Continuation Ledger was created, whether Pi reported package-owned `pi-continue/v4` handoff proof, which summarizer model ran, the requested and effective history output budget, whether the model max-output cap clamped that budget, whether the resume request was sent, whether the resumed assistant turn completed, whether continuation-artifact or agent-guide output writes updated anything, and what to do next. If the resumed assistant requests tools, status remains in resume-running state while that tool-use loop is still live; `toolUse` alone is not treated as completion. A later completed assistant/tool-result checkpoint can start the next automatic continuation as a chained handoff when the context is still over threshold, otherwise the resume clears when a terminal assistant outcome (`stop`, `length`, `aborted`, or failure) is observed. UI sessions can also show the latest Continuation Ledger as a temporary panel; this never appends another transcript entry. Failure states use explicit package messages rather than parsing provider error text.
+Use `/continue status` after a continuation to see what happened. Status reports the latest local run: how the handoff started, whether the Continuation Ledger was created, whether Pi reported package-owned `pi-continue/v4` handoff proof, which summarizer model ran, the requested and effective history output budget, whether the model max-output cap clamped that budget, whether the resume request was sent, whether the resumed assistant turn completed, whether continuation-artifact or agent-guide output writes updated anything, and what to do next. If the resumed assistant requests tools, status remains in resume-running state while that tool-use loop is still live; `toolUse` alone is not treated as completion. A later completed assistant/tool-result checkpoint can start the next automatic continuation as a chained handoff when the context is still over threshold, otherwise the resume clears when a terminal assistant outcome (`stop`, `length`, `aborted`, or failure) is observed. UI sessions can also show the latest Continuation Ledger as a temporary panel; repeated displays reuse and focus the same panel with the latest ledger instead of stacking overlays, and this never appends another transcript entry. Failure states use explicit package messages rather than parsing provider error text.
 
 A model's context window and maximum output budget are independent. `pi-continue` derives the history budget from Pi's reserve-token setting or `historyMaxTokens`, then clamps the provider request to the selected summarizer model's positive max-output limit when that limit is known.
 
@@ -144,7 +144,7 @@ Common settings:
 | `appendReadFileTags` | `false` by default; when true, appends current compaction read-file tags. |
 | `appendModifiedFileTags` | `true` by default; when true, appends current compaction modified-file tags. |
 | `promptOverridePolicy` | Chooses project overrides, global overrides, or package defaults. |
-| `showAfterCompact` | `true` by default; surfaces the rendered brief in a temporary TUI panel right after each successful extension-owned compaction. Set `false` for a silent handoff. |
+| `showAfterCompact` | `true` by default; surfaces the rendered brief in a temporary TUI panel right after each successful extension-owned compaction. Repeated displays update and focus the latest panel instead of stacking overlays. Set `false` for a silent handoff. |
 
 `/continue settings` also includes a handoff trigger control. It shows one human-facing trigger token count and writes Pi core `compaction.reserveTokens` in `.pi/settings.json` or the global Pi settings file, not a package config key.
 
@@ -223,7 +223,7 @@ What can change:
 
 - `continuationArtifactMode: "always"` writes the rendered brief under `.pi/continue/` after successful extension-owned compaction.
 - `continuationArtifactMode: "off"` writes no continuation artifact.
-- `showAfterCompact: true` (default) surfaces the rendered brief in a TUI overlay right after compaction completes; set `false` for a silent handoff.
+- `showAfterCompact: true` (default) surfaces the rendered brief in a TUI overlay right after compaction completes and reuses the latest panel for repeated displays; set `false` for a silent handoff.
 - `agentGuideSyncMode: "off"` is the default.
 - `agentGuideSyncMode: "always"` writes only a full non-null `agentGuideUpdate.content` replacement to the configured agent-guide path.
 - Writes are normalized and skipped when content is unchanged.

--- a/extensions/continue/index.ts
+++ b/extensions/continue/index.ts
@@ -23,7 +23,7 @@ import {
 } from "./src/continuation-event.ts";
 import { buildContinuationDetails, buildContinuationSynthesisTelemetry, parseContinuationDetails } from "./src/details.ts";
 import { SYNTHESIS_ABORT_MESSAGE } from "./src/synthesis-error.ts";
-import { buildLedgerSnapshot, showContinuationLedgerOverlaySoon } from "./src/ledger-viewer.ts";
+import { buildLedgerSnapshot, createContinuationLedgerOverlayController } from "./src/ledger-viewer.ts";
 import { runMidRunGuard } from "./src/mid-run-guard.ts";
 import { PromptPassError, runPromptPass } from "./src/model.ts";
 import { loadPiInternals } from "./src/pi-internals.ts";
@@ -94,6 +94,7 @@ function normalizeSynthesisFailure(error: unknown): ContinuationSynthesisFailure
 export default function (pi: ExtensionAPI) {
 	const pendingOutputWrites = new Map<string, PendingOutputWrite>();
 	const runtime = createContinuationRuntimeState();
+	const ledgerOverlay = createContinuationLedgerOverlayController();
 
 	function cleanupPendingOutputWrites(eventId: string): void {
 		let removed = false;
@@ -114,7 +115,9 @@ export default function (pi: ExtensionAPI) {
 			if (shouldOpenContinuePalette(args, ctx.hasUI)) {
 				const palette = await showContinuePalette(pi, ctx, runtime);
 				if (palette.supported) {
-					if (palette.result) await runContinuePaletteResult(pi, ctx, runtime, palette.result, (eventId) => cleanupPendingOutputWrites(eventId));
+					if (palette.result) {
+						await runContinuePaletteResult(pi, ctx, runtime, ledgerOverlay, palette.result, (eventId) => cleanupPendingOutputWrites(eventId));
+					}
 					return;
 				}
 			}
@@ -124,7 +127,7 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 			if (subcommand?.name === "ledger") {
-				await runLedgerCommand(ctx, runtime);
+				await runLedgerCommand(ctx, runtime, ledgerOverlay);
 				return;
 			}
 			if (subcommand?.name === "settings") {
@@ -367,7 +370,7 @@ export default function (pi: ExtensionAPI) {
 			const projectContext = await resolveProjectContext(pi, ctx.cwd, ctx.sessionManager.getSessionId());
 			const config = loadContinuationConfig(projectContext.projectRoot);
 			if (config.enabled && config.showAfterCompact) {
-				showContinuationLedgerOverlaySoon(ctx, ledger, (reason) => {
+				ledgerOverlay.showSoon(ctx, ledger, (reason) => {
 					if (ctx.hasUI) ctx.ui.notify(`Could not open Continuation Ledger: ${reason}`, "error");
 				});
 			}
@@ -406,6 +409,7 @@ export default function (pi: ExtensionAPI) {
 		abandonActiveContinuationEvent(runtime, "Pi session shut down before continuation finished settling.");
 		pendingOutputWrites.clear();
 		clearWorkingVisuals(ctx, runtime);
+		ledgerOverlay.clear();
 		runtime.compactionRunning = false;
 		runtime.guardFailureKey = undefined;
 		clearResumeStartTimeout(runtime);

--- a/extensions/continue/src/command-runner.ts
+++ b/extensions/continue/src/command-runner.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-c
 import { buildContinuationCommandArgs } from "./command-shape.ts";
 import { runLedgerCommand, runPreviewCommand, runResetCommand, runSettingsDialog, runStatusCommand } from "./commands.ts";
 import { loadContinuationConfig } from "./config.ts";
+import type { ContinuationLedgerOverlayController } from "./ledger-viewer.ts";
 import type { ContinuePaletteResult } from "./palette-actions.ts";
 import { sendContinuationPrompt } from "./prompt-dispatch.ts";
 import { resolveProjectContext } from "./project.ts";
@@ -35,6 +36,7 @@ export async function runContinuePaletteResult(
 	pi: ExtensionAPI,
 	ctx: ExtensionCommandContext,
 	runtime: ContinuationRuntimeState,
+	ledgerOverlay: ContinuationLedgerOverlayController,
 	result: ContinuePaletteResult,
 	onContinuationFailed: (eventId: string) => void,
 ): Promise<void> {
@@ -43,7 +45,7 @@ export async function runContinuePaletteResult(
 		return;
 	}
 	if (result.kind === "ledger") {
-		await runLedgerCommand(ctx, runtime);
+		await runLedgerCommand(ctx, runtime, ledgerOverlay);
 		return;
 	}
 	if (result.kind === "settings") {

--- a/extensions/continue/src/commands.ts
+++ b/extensions/continue/src/commands.ts
@@ -5,7 +5,7 @@ import { loadHistoryPromptAssets } from "./assets.ts";
 import { normalizeCompactionPreparation, snapshotFileOperations, stripCompactionPreparationMessages, type ContinuationCompactionPreparation } from "./compaction-preparation.ts";
 import { CONTINUATION_PROMPT } from "./continuation-prompt.ts";
 import { loadContinuationConfig, loadScopeConfig, patchContinuationConfig, resetContinuationConfig } from "./config.ts";
-import { showLatestContinuationLedger } from "./ledger-viewer.ts";
+import { showLatestContinuationLedger, type ContinuationLedgerOverlayController } from "./ledger-viewer.ts";
 import { showScrollableTextOverlay } from "./text-viewer.ts";
 import { readEffectivePiCompactionSettings } from "./pi-settings.ts";
 import { renderHandoffTrigger, updateHandoffTriggerFromDialog } from "./pi-threshold-settings.ts";
@@ -339,8 +339,8 @@ export async function runStatusCommand(pi: ExtensionAPI, ctx: ExtensionCommandCo
 }
 
 /** Show the latest in-memory Continuation Ledger without mutating the transcript. */
-export async function runLedgerCommand(ctx: ExtensionCommandContext, runtime: ContinuationRuntimeState): Promise<void> {
-	await showLatestContinuationLedger(ctx, getLatestContinuationLedger(runtime));
+export async function runLedgerCommand(ctx: ExtensionCommandContext, runtime: ContinuationRuntimeState, ledgerOverlay: ContinuationLedgerOverlayController): Promise<void> {
+	await showLatestContinuationLedger(ctx, getLatestContinuationLedger(runtime), ledgerOverlay);
 }
 
 /** Reset scoped config. */

--- a/extensions/continue/src/key-input.ts
+++ b/extensions/continue/src/key-input.ts
@@ -1,0 +1,123 @@
+import {
+	decodeKittyPrintable,
+	Key,
+	matchesKey,
+	parseKey,
+	StdinBuffer,
+	type KeyId,
+} from "@earendil-works/pi-tui";
+
+type TextKey = "up" | "down" | "page-up" | "page-down" | "home" | "end" | "close";
+type PaletteKey =
+	| "up"
+	| "down"
+	| "left"
+	| "right"
+	| "enter"
+	| "escape"
+	| "ctrl-c"
+	| "ctrl-u"
+	| "backspace"
+	| "delete"
+	| "home"
+	| "end";
+
+const TEXT_KEY_IDS: Record<TextKey, readonly KeyId[]> = {
+	up: [Key.up, "k"],
+	down: [Key.down, "j"],
+	"page-up": [Key.pageUp],
+	"page-down": [Key.pageDown],
+	home: [Key.home],
+	end: [Key.end],
+	close: [Key.enter, Key.return, Key.escape, Key.esc, Key.ctrl("c"), "q"],
+};
+
+const TEXT_KEY_ALIASES: Partial<Record<TextKey, readonly string[]>> = {
+	"page-up": ["pageup", "page-up"],
+	"page-down": ["pagedown", "page-down"],
+};
+
+const PALETTE_KEY_IDS: Record<PaletteKey, readonly KeyId[]> = {
+	up: [Key.up],
+	down: [Key.down],
+	left: [Key.left],
+	right: [Key.right],
+	enter: [Key.enter, Key.return],
+	escape: [Key.escape, Key.esc],
+	"ctrl-c": [Key.ctrl("c")],
+	"ctrl-u": [Key.ctrl("u")],
+	backspace: [Key.backspace],
+	delete: [Key.delete],
+	home: [Key.home],
+	end: [Key.end],
+};
+
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001f\u007f-\u009f]/;
+
+function splitInput(data: string): string[] {
+	const buffer = new StdinBuffer({ timeout: 1_000 });
+	const events: string[] = [];
+	buffer.on("data", (event) => events.push(event));
+	buffer.process(data);
+	events.push(...buffer.flush());
+	buffer.destroy();
+	return events.length > 0 ? events : [data];
+}
+
+function matchesKeyId(data: string, keyIds: readonly KeyId[], aliases: readonly string[] = []): boolean {
+	return keyIds.includes(data as KeyId) || aliases.includes(data) || keyIds.some((keyId) => matchesKey(data, keyId));
+}
+
+export function keyRepeat(data: string, key: TextKey): number {
+	const keyIds = TEXT_KEY_IDS[key];
+	const aliases = TEXT_KEY_ALIASES[key] ?? [];
+	if (matchesKeyId(data, keyIds, aliases)) return 1;
+	let count = 0;
+	for (const event of splitInput(data)) {
+		if (!matchesKeyId(event, keyIds, aliases)) return 0;
+		count += 1;
+	}
+	return count;
+}
+
+export function keyMatches(data: string, key: PaletteKey): boolean {
+	return matchesKeyId(data, PALETTE_KEY_IDS[key]);
+}
+
+export function paletteShortcutMatches(data: string, key: KeyId): boolean {
+	return matchesKeyId(data, [key]);
+}
+
+function printableEvent(data: string): string | undefined {
+	const kittyPrintable = decodeKittyPrintable(data);
+	if (kittyPrintable !== undefined) {
+		return isRawPrintableText(kittyPrintable);
+	}
+	const parsed = parseKey(data);
+	if (parsed === Key.space) return " ";
+	return parsed?.length === 1 ? parsed : undefined;
+}
+
+function isRawPrintableText(data: string): string | undefined {
+	if (data.length === 0) return undefined;
+	if (data.includes("\u001b")) return undefined;
+	if (CONTROL_CHAR_PATTERN.test(data)) return undefined;
+	return data;
+}
+
+export function palettePrintableInput(data: string): string | undefined {
+	const direct = printableEvent(data);
+	if (direct !== undefined) return direct;
+	let output = "";
+	for (const event of splitInput(data)) {
+		const printable = printableEvent(event);
+		if (printable !== undefined) {
+			output += printable;
+			continue;
+		}
+		const raw = isRawPrintableText(event);
+		if (raw === undefined) return undefined;
+		output += raw;
+	}
+	return output.length > 0 ? output : undefined;
+}

--- a/extensions/continue/src/ledger-viewer.ts
+++ b/extensions/continue/src/ledger-viewer.ts
@@ -1,11 +1,30 @@
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { extractTaggedBlock } from "./blocks.ts";
-import { ScrollableTextOverlay, sanitizeOverlayText, showScrollableTextOverlay } from "./text-viewer.ts";
+import { ScrollableTextOverlay, sanitizeOverlayText } from "./text-viewer.ts";
 import type { ContinuationLedgerSnapshot } from "./types.ts";
 
 interface LedgerTheme {
 	fg(color: "accent" | "border" | "dim" | "muted", text: string): string;
 	bold(text: string): string;
+}
+
+interface LedgerOverlayHandle {
+	focus(): void;
+	hide(): void;
+}
+
+interface TrackedLedgerOverlay {
+	overlay: ContinuationLedgerOverlay;
+	handle: LedgerOverlayHandle | undefined;
+	closedByUser: boolean;
+	closeRequested: boolean;
+	pendingFocus: boolean;
+}
+
+export interface ContinuationLedgerOverlayController {
+	clear(): void;
+	show(ctx: ExtensionContext, ledger: ContinuationLedgerSnapshot): Promise<boolean>;
+	showSoon(ctx: ExtensionContext, ledger: ContinuationLedgerSnapshot, onError: (reason: string) => void): void;
 }
 
 function ledgerHeaderLines(ledger: ContinuationLedgerSnapshot): string[] {
@@ -22,17 +41,20 @@ export class ContinuationLedgerOverlay extends ScrollableTextOverlay {
 		done: () => void,
 		requestRender: () => void,
 	) {
-		super(
-			{
-				title: "Continuation Ledger",
-				content: ledger.content,
-				headerLines: ledgerHeaderLines(ledger),
-			},
-			theme,
-			done,
-			requestRender,
-		);
+		super(ledgerOverlayOptions(ledger), theme, done, requestRender);
 	}
+
+	setLedger(ledger: ContinuationLedgerSnapshot): void {
+		this.update(ledgerOverlayOptions(ledger));
+	}
+}
+
+function ledgerOverlayOptions(ledger: ContinuationLedgerSnapshot) {
+	return {
+		title: "Continuation Ledger",
+		content: ledger.content,
+		headerLines: ledgerHeaderLines(ledger),
+	};
 }
 
 export function extractContinuationLedger(summary: string): string | undefined {
@@ -54,58 +76,106 @@ export function buildLedgerSnapshot(
 	};
 }
 
-export async function showContinuationLedgerOverlay(
-	ctx: ExtensionContext,
-	ledger: ContinuationLedgerSnapshot,
-): Promise<boolean> {
-	if (!ctx.hasUI) return false;
-	let supported = false;
-	await ctx.ui.custom<void>(
-		(tui, theme, _keybindings, done) => {
-			supported = true;
-			return new ContinuationLedgerOverlay(ledger, theme, () => done(), () => tui.requestRender());
-		},
-		{
-			overlay: true,
-			overlayOptions: {
-				width: 92,
-				minWidth: 48,
-				maxHeight: 24,
-				anchor: "center",
-				margin: 1,
-			},
-		},
-	);
-	return supported;
-}
+export function createContinuationLedgerOverlayController(): ContinuationLedgerOverlayController {
+	let activeLedgerOverlay: TrackedLedgerOverlay | undefined;
 
-export function showContinuationLedgerOverlaySoon(
-	ctx: ExtensionContext,
-	ledger: ContinuationLedgerSnapshot,
-	onError: (reason: string) => void,
-): void {
-	void showContinuationLedgerOverlay(ctx, ledger)
-		.then((shown) => {
-			if (!shown) onError("Continuation Ledger cannot open in this Pi mode.");
-		})
-		.catch(() => {
-			onError("Continuation Ledger could not open.");
-		});
+	function forgetLedgerOverlay(entry: TrackedLedgerOverlay | undefined): void {
+		if (activeLedgerOverlay === entry) activeLedgerOverlay = undefined;
+	}
+
+	function clear(): void {
+		const entry = activeLedgerOverlay;
+		if (!entry) return;
+		entry.closeRequested = true;
+		forgetLedgerOverlay(entry);
+		if (!entry.closedByUser) entry.handle?.hide();
+	}
+
+	async function show(ctx: ExtensionContext, ledger: ContinuationLedgerSnapshot, onLifecycleError?: () => void): Promise<boolean> {
+		if (!ctx.hasUI) return false;
+		if (activeLedgerOverlay) {
+			activeLedgerOverlay.overlay.setLedger(ledger);
+			if (activeLedgerOverlay.handle) {
+				activeLedgerOverlay.handle.focus();
+			} else {
+				activeLedgerOverlay.pendingFocus = true;
+			}
+			return true;
+		}
+		let supported = false;
+		let entry: TrackedLedgerOverlay | undefined;
+		const lifecycle = ctx.ui.custom<void>(
+			(tui, theme, _keybindings, done) => {
+				supported = true;
+				const overlay = new ContinuationLedgerOverlay(ledger, theme, () => {
+					if (entry) entry.closedByUser = true;
+					done();
+				}, () => tui.requestRender());
+				entry = { overlay, handle: undefined, closedByUser: false, closeRequested: false, pendingFocus: false };
+				activeLedgerOverlay = entry;
+				return overlay;
+			},
+			{
+				overlay: true,
+				overlayOptions: {
+					width: 92,
+					minWidth: 48,
+					maxHeight: 24,
+					anchor: "center",
+					margin: 1,
+				},
+				onHandle: (handle) => {
+					if (!entry) return;
+					entry.handle = handle;
+					if (entry.closeRequested) {
+						handle.hide();
+						return;
+					}
+					if (entry.pendingFocus) {
+						entry.pendingFocus = false;
+						handle.focus();
+					}
+				},
+			},
+		);
+		void lifecycle
+			.catch(() => {
+				if (activeLedgerOverlay === entry) onLifecycleError?.();
+			})
+			.finally(() => {
+				forgetLedgerOverlay(entry);
+			});
+		await Promise.resolve();
+		return supported;
+	}
+
+	function showSoon(ctx: ExtensionContext, ledger: ContinuationLedgerSnapshot, onError: (reason: string) => void): void {
+		void show(ctx, ledger, () => onError("Continuation Ledger could not open."))
+			.then((shown) => {
+				if (!shown) onError("Continuation Ledger cannot open in this Pi mode.");
+			})
+			.catch(() => {
+				onError("Continuation Ledger could not open.");
+			});
+	}
+
+	return {
+		clear,
+		show,
+		showSoon,
+	};
 }
 
 export async function showLatestContinuationLedger(
 	ctx: ExtensionCommandContext,
 	ledger: ContinuationLedgerSnapshot | undefined,
+	overlay: ContinuationLedgerOverlayController,
 ): Promise<void> {
 	if (!ledger) {
 		if (ctx.hasUI) ctx.ui.notify("No Continuation Ledger has been created in this session yet.", "warning");
 		return;
 	}
-	const shown = await showScrollableTextOverlay(ctx, {
-		title: "Continuation Ledger",
-		content: ledger.content,
-		headerLines: ledgerHeaderLines(ledger),
-	});
+	const shown = await overlay.show(ctx, ledger);
 	if (!shown && ctx.hasUI) {
 		ctx.ui.notify("Continuation Ledger cannot open in this Pi mode.", "warning");
 	}

--- a/extensions/continue/src/palette.ts
+++ b/extensions/continue/src/palette.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { loadContinuationConfig } from "./config.ts";
+import { keyMatches, palettePrintableInput, paletteShortcutMatches } from "./key-input.ts";
 import { readEffectivePiCompactionSettings } from "./pi-settings.ts";
 import { resolveProjectContext } from "./project.ts";
 import type { ContinuationRuntimeState } from "./runtime.ts";
@@ -30,29 +31,6 @@ interface FocusDraft {
 	actionId: FocusActionId;
 	text: string;
 	cursor: number;
-}
-
-function keyMatches(data: string, key: "up" | "down" | "left" | "right" | "enter" | "escape" | "ctrl-c" | "backspace" | "delete" | "home" | "end"): boolean {
-	if (key === "up") return data === "up" || data === "\u001b[A";
-	if (key === "down") return data === "down" || data === "\u001b[B";
-	if (key === "left") return data === "left" || data === "\u001b[D";
-	if (key === "right") return data === "right" || data === "\u001b[C";
-	if (key === "enter") return data === "enter" || data === "return" || data === "\r" || data === "\n";
-	if (key === "escape") return data === "escape" || data === "\u001b";
-	if (key === "ctrl-c") return data === "ctrl+c" || data === "\u0003";
-	if (key === "backspace") return data === "backspace" || data === "\u007f" || data === "\b";
-	if (key === "delete") return data === "delete" || data === "\u001b[3~";
-	if (key === "home") return data === "home" || data === "\u001b[H" || data === "\u001b[1~";
-	return data === "end" || data === "\u001b[F" || data === "\u001b[4~";
-}
-
-function isPrintable(data: string): boolean {
-	if (data.length === 0) return false;
-	for (const char of data) {
-		const code = char.codePointAt(0);
-		if (code === undefined || code < 32 || code === 127) return false;
-	}
-	return !data.includes("\u001b");
 }
 
 function topLine(theme: PaletteTheme, width: number, title: string): string {
@@ -204,7 +182,7 @@ export class ContinuePaletteComponent {
 			return;
 		}
 		const selectedAction = this.selectedAction();
-		if (data.toLowerCase() === "f" && isFocusActionId(selectedAction.id)) {
+		if (paletteShortcutMatches(data, "f") && isFocusActionId(selectedAction.id)) {
 			this.focusDraft = { actionId: selectedAction.id, text: "", cursor: 0 };
 			this.requestRender();
 		}
@@ -258,14 +236,14 @@ export class ContinuePaletteComponent {
 				const next = nextCursorIndex(draft.text, draft.cursor);
 				draft.text = `${draft.text.slice(0, draft.cursor)}${draft.text.slice(next)}`;
 			}
-		} else if (data === "\u0015") {
+		} else if (keyMatches(data, "ctrl-u")) {
 			draft.text = draft.text.slice(draft.cursor);
 			draft.cursor = 0;
-		} else if (isPrintable(data)) {
-			draft.text = `${draft.text.slice(0, draft.cursor)}${data}${draft.text.slice(draft.cursor)}`;
-			draft.cursor += data.length;
 		} else {
-			return;
+			const printable = palettePrintableInput(data);
+			if (printable === undefined) return;
+			draft.text = `${draft.text.slice(0, draft.cursor)}${printable}${draft.text.slice(draft.cursor)}`;
+			draft.cursor += printable.length;
 		}
 		this.requestRender();
 	}

--- a/extensions/continue/src/text-viewer.ts
+++ b/extensions/continue/src/text-viewer.ts
@@ -1,4 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Focusable } from "@earendil-works/pi-tui";
+import { keyRepeat } from "./key-input.ts";
 import { padVisible, stripAnsi, truncateAnsi, visibleWidth } from "./tui-text.ts";
 
 const MIN_WIDTH = 48;
@@ -6,14 +8,6 @@ const TARGET_WIDTH = 92;
 const MAX_HEIGHT = 24;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g;
 const ESCAPE_CHARACTER_PATTERN = /\u001b/g;
-const KITTY_UP_PATTERN = /^\u001b\[1;1(?::[12])?A/;
-const KITTY_DOWN_PATTERN = /^\u001b\[1;1(?::[12])?B/;
-const KITTY_HOME_PATTERN = /^\u001b\[1;1(?::[12])?H/;
-const KITTY_END_PATTERN = /^\u001b\[1;1(?::[12])?F/;
-const KITTY_PAGE_UP_PATTERN = /^\u001b\[5(?:;1)?(?::[12])?~/;
-const KITTY_PAGE_DOWN_PATTERN = /^\u001b\[6(?:;1)?(?::[12])?~/;
-const KITTY_HOME_FUNCTION_PATTERN = /^\u001b\[7(?:;1)?(?::[12])?~/;
-const KITTY_END_FUNCTION_PATTERN = /^\u001b\[8(?:;1)?(?::[12])?~/;
 
 type ViewerColor = "accent" | "border" | "dim" | "muted";
 
@@ -38,21 +32,29 @@ export function sanitizeOverlayText(content: string): string {
 		.replace(ESCAPE_CHARACTER_PATTERN, "");
 }
 
-function topLine(theme: ViewerTheme, width: number, title: string): string {
+function borderColor(focused: boolean): ViewerColor {
+	return focused ? "border" : "muted";
+}
+
+function titleColor(focused: boolean): ViewerColor {
+	return focused ? "accent" : "dim";
+}
+
+function topLine(theme: ViewerTheme, width: number, title: string, focused: boolean): string {
 	const label = ` ${title} `;
 	const fill = Math.max(0, width - visibleWidth(label) - 2);
-	return `${theme.fg("border", "+")}${theme.fg("accent", label)}${theme.fg("border", `${"-".repeat(fill)}+`)}`;
+	return `${theme.fg(borderColor(focused), "+")}${theme.fg(titleColor(focused), label)}${theme.fg(borderColor(focused), `${"-".repeat(fill)}+`)}`;
 }
 
-function bottomLine(theme: ViewerTheme, width: number): string {
+function bottomLine(theme: ViewerTheme, width: number, focused: boolean): string {
 	const inner = Math.max(0, width - 2);
-	return theme.fg("border", `+${"-".repeat(inner)}+`);
+	return theme.fg(borderColor(focused), `+${"-".repeat(inner)}+`);
 }
 
-function frame(theme: ViewerTheme, width: number, content: string): string {
+function frame(theme: ViewerTheme, width: number, content: string, focused: boolean): string {
 	const inner = Math.max(0, width - 2);
 	const safe = padVisible(truncateAnsi(content, inner), inner);
-	return `${theme.fg("border", "|")}${safe}${theme.fg("border", "|")}`;
+	return `${theme.fg(borderColor(focused), "|")}${safe}${theme.fg(borderColor(focused), "|")}`;
 }
 
 function wrapPlainLine(line: string, width: number): string[] {
@@ -83,57 +85,15 @@ function prepareTextLines(content: string, width: number): string[] {
 	return result.length > 0 ? result : ["(empty)"];
 }
 
-function repeatCount(data: string, sequences: string[]): number {
-	for (const sequence of sequences) {
-		if (data === sequence) return 1;
-		if (sequence.length === 0 || data.length <= sequence.length) continue;
-		if (data.length % sequence.length !== 0) continue;
-		const count = data.length / sequence.length;
-		if (sequence.repeat(count) === data) return count;
-	}
-	return 0;
-}
-
-function repeatedPatternCount(data: string, patterns: RegExp[]): number {
-	for (const pattern of patterns) {
-		let index = 0;
-		let count = 0;
-		while (index < data.length) {
-			const match = pattern.exec(data.slice(index));
-			if (!match || match.index !== 0 || match[0].length === 0) {
-				count = 0;
-				break;
-			}
-			index += match[0].length;
-			count += 1;
-		}
-		if (count > 0) return count;
-	}
-	return 0;
-}
-
-function repeatCountFor(data: string, sequences: string[], patterns: RegExp[]): number {
-	return Math.max(repeatCount(data, sequences), repeatedPatternCount(data, patterns));
-}
-
-function keyRepeat(data: string, key: "up" | "down" | "page-up" | "page-down" | "home" | "end" | "close"): number {
-	if (key === "up") return repeatCountFor(data, ["up", "k", "\u001b[A", "\u001bOA"], [KITTY_UP_PATTERN]);
-	if (key === "down") return repeatCountFor(data, ["down", "j", "\u001b[B", "\u001bOB"], [KITTY_DOWN_PATTERN]);
-	if (key === "page-up") return repeatCountFor(data, ["pageup", "page-up", "\u001b[5~", "\u001b[[5~"], [KITTY_PAGE_UP_PATTERN]);
-	if (key === "page-down") return repeatCountFor(data, ["pagedown", "page-down", "\u001b[6~", "\u001b[[6~"], [KITTY_PAGE_DOWN_PATTERN]);
-	if (key === "home") return repeatCountFor(data, ["home", "\u001b[H", "\u001bOH", "\u001b[1~", "\u001b[7~"], [KITTY_HOME_PATTERN, KITTY_HOME_FUNCTION_PATTERN]);
-	if (key === "end") return repeatCountFor(data, ["end", "\u001b[F", "\u001bOF", "\u001b[4~", "\u001b[8~"], [KITTY_END_PATTERN, KITTY_END_FUNCTION_PATTERN]);
-	return repeatCount(data, ["enter", "return", "\r", "\n", "escape", "q", "\u001b", "ctrl+c", "\u0003"]);
-}
-
-export class ScrollableTextOverlay {
+export class ScrollableTextOverlay implements Focusable {
+	focused = false;
 	private scroll = 0;
 	private cachedWidth: number | undefined;
 	private cachedLines: string[] | undefined;
-	private readonly title: string;
-	private readonly content: string;
-	private readonly headerLines: string[];
-	private readonly footer: string;
+	private title: string;
+	private content: string;
+	private headerLines: string[];
+	private footer: string;
 	private readonly theme: ViewerTheme;
 	private readonly done: () => void;
 	private readonly requestRender: () => void;
@@ -151,6 +111,16 @@ export class ScrollableTextOverlay {
 		this.theme = theme;
 		this.done = done;
 		this.requestRender = requestRender;
+	}
+
+	update(options: ScrollableTextOverlayOptions): void {
+		this.title = sanitizeOverlayText(options.title).trim() || "Preview";
+		this.content = sanitizeOverlayText(options.content);
+		this.headerLines = (options.headerLines ?? []).map((line) => sanitizeOverlayText(line));
+		this.footer = options.footer ?? "↑↓/j/k scroll | PgUp/PgDn page | Enter/q/Esc close";
+		this.scroll = 0;
+		this.invalidate();
+		this.requestRender();
 	}
 
 	handleInput(data: string): void {
@@ -183,18 +153,20 @@ export class ScrollableTextOverlay {
 		const maxScroll = Math.max(0, content.length - page);
 		this.scroll = Math.min(this.scroll, maxScroll);
 		const visible = content.slice(this.scroll, this.scroll + page);
+		const focused = this.focused;
 		const scrollLabel = content.length > page
 			? `lines ${this.scroll + 1}-${Math.min(content.length, this.scroll + page)} of ${content.length}`
 			: `${content.length} lines`;
+		const footer = focused ? this.footer : "Inactive: focus this panel to scroll or close";
 		return [
-			topLine(this.theme, overlayWidth, this.title),
-			...this.headerLines.map((line) => frame(this.theme, overlayWidth, ` ${this.theme.fg("dim", line)}`)),
-			frame(this.theme, overlayWidth, ` ${this.theme.fg("dim", scrollLabel)}`),
-			frame(this.theme, overlayWidth, ""),
-			...visible.map((line) => frame(this.theme, overlayWidth, ` ${line}`)),
-			frame(this.theme, overlayWidth, ""),
-			frame(this.theme, overlayWidth, ` ${this.theme.fg("dim", this.footer)}`),
-			bottomLine(this.theme, overlayWidth),
+			topLine(this.theme, overlayWidth, this.title, focused),
+			...this.headerLines.map((line) => frame(this.theme, overlayWidth, ` ${this.theme.fg("dim", line)}`, focused)),
+			frame(this.theme, overlayWidth, ` ${this.theme.fg("dim", scrollLabel)}`, focused),
+			frame(this.theme, overlayWidth, "", focused),
+			...visible.map((line) => frame(this.theme, overlayWidth, ` ${line}`, focused)),
+			frame(this.theme, overlayWidth, "", focused),
+			frame(this.theme, overlayWidth, ` ${this.theme.fg("dim", footer)}`, focused),
+			bottomLine(this.theme, overlayWidth, focused),
 		];
 	}
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.74.0",
-    "@earendil-works/pi-coding-agent": ">=0.74.0"
+    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-tui": ">=0.74.0"
   },
   "pi": {
     "extensions": [
@@ -56,6 +57,7 @@
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.74.0",
     "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
     "@types/node": "^25.6.1",
     "typescript": "^6.0.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: ^0.74.0
         version: 0.74.0(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: ^0.74.0
+        version: 0.74.0
       '@types/node':
         specifier: ^25.6.1
         version: 25.6.1

--- a/tests/docs.test.ts
+++ b/tests/docs.test.ts
@@ -150,6 +150,8 @@ test("package metadata and package contents align with the public contract", () 
 	]);
 	assert.equal(packageJson.peerDependencies["@earendil-works/pi-ai"], ">=0.74.0");
 	assert.equal(packageJson.peerDependencies["@earendil-works/pi-coding-agent"], ">=0.74.0");
+	assert.equal(packageJson.peerDependencies["@earendil-works/pi-tui"], ">=0.74.0");
+	assert.equal(packageJson.devDependencies["@earendil-works/pi-tui"], "^0.74.0");
 	assert.deepEqual(packageJson.pi.extensions, ["./extensions/continue/index.ts"]);
 	assert.equal(packageJson.pi.image, "https://raw.githubusercontent.com/Tiziano-AI/pi-continue/v0.8.2/assets/gallery/pi-continue-gallery.webp");
 	assert.equal(existsSync("assets/gallery/pi-continue-gallery.webp"), true);

--- a/tests/ledger-viewer.test.ts
+++ b/tests/ledger-viewer.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildLedgerSnapshot, ContinuationLedgerOverlay, extractContinuationLedger, showContinuationLedgerOverlay } from "../extensions/continue/src/ledger-viewer.ts";
+import { buildLedgerSnapshot, createContinuationLedgerOverlayController, ContinuationLedgerOverlay, extractContinuationLedger, showLatestContinuationLedger } from "../extensions/continue/src/ledger-viewer.ts";
 
 const theme = {
 	fg(_color, text) {
@@ -42,9 +42,10 @@ test("buildLedgerSnapshot strips terminal control sequences from untrusted conte
 	assert.doesNotMatch(snapshot.content, /\u001b|\u0007|\u0000/);
 });
 
-test("showContinuationLedgerOverlay reports unsupported custom UI", async () => {
+test("Continuation Ledger overlay controller reports unsupported custom UI", async () => {
 	let factoryInvoked = false;
-	const shown = await showContinuationLedgerOverlay(
+	const overlay = createContinuationLedgerOverlayController();
+	const shown = await overlay.show(
 		{
 			hasUI: true,
 			ui: {
@@ -60,9 +61,10 @@ test("showContinuationLedgerOverlay reports unsupported custom UI", async () => 
 	assert.equal(shown, false);
 });
 
-test("showContinuationLedgerOverlay reports supported custom UI", async () => {
+test("Continuation Ledger overlay controller reports supported custom UI", async () => {
 	let factoryInvoked = false;
-	const shown = await showContinuationLedgerOverlay(
+	const overlay = createContinuationLedgerOverlayController();
+	const shown = await overlay.show(
 		{
 			hasUI: true,
 			ui: {
@@ -75,8 +77,154 @@ test("showContinuationLedgerOverlay reports supported custom UI", async () => {
 		},
 		{ eventId: "continue-1", compactionEntryId: "compact-1", content: "ledger", capturedAt: 0 },
 	);
+	overlay.clear();
 	assert.equal(factoryInvoked, true);
 	assert.equal(shown, true);
+});
+
+test("Continuation Ledger overlay controller updates and focuses the active singleton", async () => {
+	let customCalls = 0;
+	let focusCalls = 0;
+	let requestRenders = 0;
+	let hidden = false;
+	let resolveOverlay;
+	const ctx = {
+		hasUI: true,
+		ui: {
+			custom(factory, options) {
+				customCalls += 1;
+				factory(
+					{ requestRender() { requestRenders += 1; } },
+					theme,
+					{},
+					() => {},
+				);
+				options.onHandle({
+					focus() { focusCalls += 1; },
+					hide() {
+						hidden = true;
+						resolveOverlay?.();
+					},
+				});
+				return new Promise((resolve) => {
+					resolveOverlay = resolve;
+				});
+			},
+		},
+	};
+	const overlay = createContinuationLedgerOverlayController();
+	const first = overlay.show(ctx, { eventId: "continue-1", compactionEntryId: "compact-1", content: "first", capturedAt: 0 });
+	await Promise.resolve();
+	assert.equal(await overlay.show(ctx, { eventId: "continue-2", compactionEntryId: "compact-2", content: "second", capturedAt: 1 }), true);
+	assert.equal(customCalls, 1);
+	assert.equal(focusCalls, 1);
+	assert.equal(requestRenders, 1);
+	overlay.clear();
+	assert.equal(hidden, true);
+	resolveOverlay?.();
+	assert.equal(await first, true);
+});
+
+test("Continuation Ledger overlay controller keeps reuse scoped per controller", async () => {
+	let firstCustomCalls = 0;
+	let secondCustomCalls = 0;
+	let firstFocusCalls = 0;
+	let secondFocusCalls = 0;
+	function createCtx(onCustom, onFocus) {
+		return {
+			hasUI: true,
+			ui: {
+				custom(factory, options) {
+					onCustom();
+					factory({ requestRender() {} }, theme, {}, () => {});
+					options.onHandle({ focus: onFocus, hide() {} });
+					return new Promise(() => {});
+				},
+			},
+		};
+	}
+	const firstOverlay = createContinuationLedgerOverlayController();
+	const secondOverlay = createContinuationLedgerOverlayController();
+	const firstCtx = createCtx(() => { firstCustomCalls += 1; }, () => { firstFocusCalls += 1; });
+	const secondCtx = createCtx(() => { secondCustomCalls += 1; }, () => { secondFocusCalls += 1; });
+	await firstOverlay.show(firstCtx, { eventId: "continue-1", compactionEntryId: "compact-1", content: "first", capturedAt: 0 });
+	await secondOverlay.show(secondCtx, { eventId: "continue-2", compactionEntryId: "compact-2", content: "second", capturedAt: 1 });
+	await firstOverlay.show(firstCtx, { eventId: "continue-3", compactionEntryId: "compact-3", content: "third", capturedAt: 2 });
+	assert.equal(firstCustomCalls, 1);
+	assert.equal(secondCustomCalls, 1);
+	assert.equal(firstFocusCalls, 1);
+	assert.equal(secondFocusCalls, 0);
+	firstOverlay.clear();
+	secondOverlay.clear();
+});
+
+test("Continuation Ledger overlay controller focuses after delayed handle delivery", async () => {
+	let focusCalls = 0;
+	let requestRenders = 0;
+	let onHandle;
+	const ctx = {
+		hasUI: true,
+		ui: {
+			custom(factory, options) {
+				factory({ requestRender() { requestRenders += 1; } }, theme, {}, () => {});
+				onHandle = options.onHandle;
+				return new Promise(() => {});
+			},
+		},
+	};
+	const overlay = createContinuationLedgerOverlayController();
+	await overlay.show(ctx, { eventId: "continue-1", compactionEntryId: "compact-1", content: "first", capturedAt: 0 });
+	await overlay.show(ctx, { eventId: "continue-2", compactionEntryId: "compact-2", content: "second", capturedAt: 1 });
+	onHandle({ focus() { focusCalls += 1; }, hide() {} });
+	assert.equal(focusCalls, 1);
+	assert.equal(requestRenders, 1);
+	overlay.clear();
+});
+
+test("showLatestContinuationLedger uses transient UI without session transcript mutation", async () => {
+	let customCalls = 0;
+	const forbiddenTranscriptSurface = new Proxy({}, {
+		get(_target, property) {
+			throw new Error(`unexpected transcript access: ${String(property)}`);
+		},
+	});
+	const ctx = {
+		hasUI: true,
+		sessionManager: forbiddenTranscriptSurface,
+		ui: {
+			custom(factory) {
+				customCalls += 1;
+				factory({ requestRender() {} }, theme, {}, () => {});
+				return Promise.resolve();
+			},
+			notify() {},
+		},
+	};
+	const overlay = createContinuationLedgerOverlayController();
+	await showLatestContinuationLedger(ctx, { eventId: "continue-1", compactionEntryId: "compact-1", content: "ledger", capturedAt: 0 }, overlay);
+	assert.equal(customCalls, 1);
+	overlay.clear();
+});
+
+test("Continuation Ledger overlay fire-and-forget display reports open failures", async () => {
+	const reasons: string[] = [];
+	const overlay = createContinuationLedgerOverlayController();
+	overlay.showSoon(
+		{
+			hasUI: true,
+			ui: {
+				custom(factory) {
+					factory({ requestRender() {} }, theme, {}, () => {});
+					return Promise.reject(new Error("open failed"));
+				},
+			},
+		},
+		{ eventId: "continue-1", compactionEntryId: "compact-1", content: "ledger", capturedAt: 0 },
+		(reason) => reasons.push(reason),
+	);
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(reasons, ["Continuation Ledger could not open."]);
 });
 
 test("ContinuationLedgerOverlay renders scrollable ledger panel", () => {
@@ -100,4 +248,25 @@ test("ContinuationLedgerOverlay renders scrollable ledger panel", () => {
 	overlay.handleInput("q");
 	assert.equal(closed, true);
 	assert.equal(renders, 0);
+});
+
+test("ContinuationLedgerOverlay updates content in place and resets scroll", () => {
+	let renders = 0;
+	const overlay = new ContinuationLedgerOverlay(
+		{ eventId: "continue-1", compactionEntryId: "compact-1", content: Array.from({ length: 40 }, (_entry, index) => `old ${index + 1}`).join("\n"), capturedAt: 0 },
+		theme,
+		() => {},
+		() => {
+			renders += 1;
+		},
+	);
+	overlay.focused = true;
+	overlay.handleInput("down");
+	assert.match(overlay.render(80).join("\n"), /old 2/);
+	overlay.setLedger({ eventId: "continue-2", compactionEntryId: "compact-2", content: "new ledger", capturedAt: 1 });
+	const text = overlay.render(80).join("\n");
+	assert.match(text, /run continue-2 \| compaction compact-2/);
+	assert.match(text, /new ledger/);
+	assert.doesNotMatch(text, /old 2/);
+	assert.equal(renders, 2);
 });

--- a/tests/palette.test.ts
+++ b/tests/palette.test.ts
@@ -86,6 +86,30 @@ test("ContinuePaletteComponent captures optional focus from the focus screen", (
 	assert.equal(renders, "finish tests".length + 1);
 });
 
+test("ContinuePaletteComponent opens focus mode with CSI-u base-layout f shortcut", () => {
+	let selected;
+	const component = new ContinuePaletteComponent(createSnapshot(), theme, (result) => {
+		selected = result;
+	}, () => {});
+	component.handleInput("\u001b[1092::102;1u");
+	for (const char of "via key identity") component.handleInput(char);
+	component.handleInput("enter");
+	assert.deepEqual(selected, { kind: "continue", mode: "steer", instructions: "via key identity" });
+});
+
+test("ContinuePaletteComponent keeps Unicode focus text and rejects CSI-u controls", () => {
+	let selected;
+	const component = new ContinuePaletteComponent(createSnapshot(), theme, (result) => {
+		selected = result;
+	}, () => {});
+	component.handleInput("f");
+	for (const char of "测试🙂é") component.handleInput(char);
+	component.handleInput("\u001b[133;1u");
+	component.handleInput("\u001b[9;1u");
+	component.handleInput("enter");
+	assert.deepEqual(selected, { kind: "continue", mode: "steer", instructions: "测试🙂é" });
+});
+
 test("ContinuePaletteComponent captures queue and preview focus actions", () => {
 	const queueResults = [];
 	const queueComponent = new ContinuePaletteComponent(createSnapshot(), theme, (result) => {
@@ -119,6 +143,18 @@ test("ContinuePaletteComponent backs out of focus mode without saving hidden tex
 	for (const char of "do not keep") component.handleInput(char);
 	component.handleInput("escape");
 	component.handleInput("enter");
+	assert.deepEqual(selected, { kind: "continue", mode: "steer", instructions: undefined });
+});
+
+test("ContinuePaletteComponent handles Pi TUI escape and enter key events", () => {
+	let selected;
+	const component = new ContinuePaletteComponent(createSnapshot(), theme, (result) => {
+		selected = result;
+	}, () => {});
+	component.handleInput("f");
+	for (const char of "do not keep") component.handleInput(char);
+	component.handleInput("\u001b[27;1u");
+	component.handleInput("\u001b[13;1u");
 	assert.deepEqual(selected, { kind: "continue", mode: "steer", instructions: undefined });
 });
 

--- a/tests/text-viewer.test.ts
+++ b/tests/text-viewer.test.ts
@@ -11,6 +11,21 @@ const theme = {
 	},
 };
 
+const colorTheme = {
+	fg(color, text) {
+		const code = {
+			accent: "\u001b[36m",
+			border: "\u001b[34m",
+			dim: "\u001b[2m",
+			muted: "\u001b[90m",
+		}[color];
+		return `${code}${text}\u001b[0m`;
+	},
+	bold(text) {
+		return text;
+	},
+};
+
 function renderedBody(overlay) {
 	return overlay.render(80).join("\n");
 }
@@ -20,6 +35,24 @@ test("sanitizeOverlayText strips terminal controls", () => {
 		sanitizeOverlayText("\u001b]2;title\u0007\u001b[31mred\u001b[0m\r\nline\u0000two"),
 		"red\nlinetwo",
 	);
+});
+
+test("ScrollableTextOverlay dims border and explains when focus is elsewhere", () => {
+	const overlay = new ScrollableTextOverlay(
+		{ title: "preview", content: "body" },
+		colorTheme,
+		() => {},
+		() => {},
+	);
+	const unfocused = renderedBody(overlay);
+	assert.match(unfocused, /\u001b\[90m\+\u001b\[0m/);
+	assert.match(unfocused, /Inactive: focus this panel to scroll or close/);
+
+	overlay.focused = true;
+	const focused = renderedBody(overlay);
+	assert.match(focused, /\u001b\[34m\+\u001b\[0m/);
+	assert.match(focused, /Enter\/q\/Esc close/);
+	assert.doesNotMatch(focused, /Inactive:/);
 });
 
 test("ScrollableTextOverlay scrolls repeated held-arrow chunks", () => {
@@ -42,6 +75,21 @@ test("ScrollableTextOverlay scrolls repeated held-arrow chunks", () => {
 	overlay.handleInput("kk");
 	const afterUp = renderedBody(overlay);
 	assert.match(afterUp, /\| line 2\s+\|/);
+});
+
+test("ScrollableTextOverlay closes on CSI-u Escape and Enter", () => {
+	let closed = 0;
+	const overlay = new ScrollableTextOverlay(
+		{ title: "preview", content: "x" },
+		theme,
+		() => {
+			closed += 1;
+		},
+		() => {},
+	);
+	overlay.handleInput("\u001b[27;1u");
+	overlay.handleInput("\u001b[13;1u");
+	assert.equal(closed, 2);
 });
 
 test("ScrollableTextOverlay scrolls Kitty repeat key events", () => {


### PR DESCRIPTION
## Summary

Fixes #2.

This maintainer-owned integration PR incorporates and refines the useful signal from #3, #4, and #5 without accepting the external branches as-is.

- Adds one Pi TUI-backed key-input owner for continuation palette and text-overlay keyboard handling.
- Fixes CSI-u Escape/Enter handling and key-identity shortcuts, including the `/continue` focus-note `f` shortcut on non-Latin/base-layout input.
- Reuses the active Continuation Ledger TUI overlay so repeated automatic displays and `/continue ledger` update/focus the latest panel instead of stacking overlays.
- Adds inactive focus-state copy/chrome for scrollable overlays: `Inactive: focus this panel to scroll or close`.
- Keeps Ledger display transient and transcript-free.

## Source signal / credits

This PR credits and refines:

- #2 by @ccaprani: original report that the focus window could not be closed reliably.
- #3 by @xz-dev: Pi TUI-backed keyboard matching direction.
- #4 by @xz-dev: Continuation Ledger overlay reuse / anti-stacking signal.
- #5 by @xz-dev: inactive overlay focus-state signal.

The implementation is maintainer-owned because the accepted behavior needed additional integration work: one input owner, physical/key-identity shortcut coverage, runtime-scoped Ledger overlay lifecycle, transcript-free Ledger display proof, focus copy cleanup, and source/docs/test/package alignment.

## Intentional non-scope

This is integration-only, not a release PR.

- No package version bump.
- No tag, npm publish, GitHub Release, or pi.dev mutation.
- `CHANGELOG.md` stays under `Unreleased`.
- The #4 auto-close/public config surface is intentionally deferred. This PR does **not** add `singleLedgerOverlay` or `ledgerOverlayAutoClose`; singleton Ledger overlay reuse is the canonical behavior under existing `showAfterCompact` and `/continue ledger`.

## Validation

Fresh local validation on `codex/tui-ledger-integration`:

- `pnpm install --frozen-lockfile` — pass.
- `pnpm run gate` — pass; 217 tests passed, plus typecheck, JSON check, and pack check.
- `git diff --check` — pass.
- `printf '{"type":"get_commands"}\n' | pi --mode rpc --no-session --no-context-files --no-skills --no-extensions -e /Users/tiziano/Code/pi-continue` — pass; exposes only `continue`.
- `npm pack --dry-run --json --ignore-scripts` — pass; package remains `0.8.2` and includes `extensions/continue/src/key-input.ts`.

Deferred proof: live rendered/interacted Pi TUI smoke was not run from this non-interactive Codex workflow. The next manual proof is `/continue`, `f note`, Esc/Enter/q close, `/continue preview`, `/continue ledger`, and repeated Ledger show/update/focus in a real Pi TUI session.
