### PR TITLE
Release pi-continue 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to `pi-continue` are documented here.
 
 ## Unreleased
 
+## 0.9.0 - 2026-07-04
+
 ### Changed
 
 - Reused the current Continuation Ledger TUI panel when a new ledger is shown, so repeated automatic displays and `/continue ledger` update and focus the latest handoff instead of stacking panels.
 - Switched continuation palette and text-overlay keyboard handling to Pi TUI key matching for Kitty/CSI-u input; text overlays also use Pi TUI event buffering for repeated key events.
+- Updated the package gallery image URL to the v0.9.0 source tag.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-continue",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "description": "Mid-turn continuation for long Pi tool runs: compact safely before context overflow, then resume the same session from a structured handoff ledger.",
   "keywords": [
@@ -52,7 +52,7 @@
     "extensions": [
       "./extensions/continue/index.ts"
     ],
-    "image": "https://raw.githubusercontent.com/Tiziano-AI/pi-continue/v0.8.2/assets/gallery/pi-continue-gallery.webp"
+    "image": "https://raw.githubusercontent.com/Tiziano-AI/pi-continue/v0.9.0/assets/gallery/pi-continue-gallery.webp"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.74.0",

--- a/tests/docs.test.ts
+++ b/tests/docs.test.ts
@@ -118,7 +118,7 @@ test("npm dry-run package contents align with the public contract", () => {
 test("package metadata and package contents align with the public contract", () => {
 	const packageJson = JSON.parse(readText("package.json"));
 	assert.equal(packageJson.name, "pi-continue");
-	assert.equal(packageJson.version, "0.8.2");
+	assert.equal(packageJson.version, "0.9.0");
 	assert.match(packageJson.description, /Mid-turn continuation/);
 	assert.match(packageJson.description, /long Pi tool runs/);
 	assert.match(packageJson.description, /context overflow/);
@@ -153,6 +153,6 @@ test("package metadata and package contents align with the public contract", () 
 	assert.equal(packageJson.peerDependencies["@earendil-works/pi-tui"], ">=0.74.0");
 	assert.equal(packageJson.devDependencies["@earendil-works/pi-tui"], "^0.74.0");
 	assert.deepEqual(packageJson.pi.extensions, ["./extensions/continue/index.ts"]);
-	assert.equal(packageJson.pi.image, "https://raw.githubusercontent.com/Tiziano-AI/pi-continue/v0.8.2/assets/gallery/pi-continue-gallery.webp");
+	assert.equal(packageJson.pi.image, "https://raw.githubusercontent.com/Tiziano-AI/pi-continue/v0.9.0/assets/gallery/pi-continue-gallery.webp");
 	assert.equal(existsSync("assets/gallery/pi-continue-gallery.webp"), true);
 });


### PR DESCRIPTION
## Summary

Release PR for pi-continue 0.9.0 after maintainer integration PR #6 landed.

- Bumps package version from 0.8.2 to 0.9.0.
- Moves the TUI input and Continuation Ledger overlay cleanup notes from Unreleased into `## 0.9.0 - 2026-07-04`.
- Updates the package gallery image URL/test expectation to the `v0.9.0` source tag.

## Included user-facing changes

- Pi TUI-backed keyboard handling for continuation palette/text overlays, including CSI-u Escape/Enter and key-identity shortcut coverage.
- Singleton/reused Continuation Ledger TUI panel for repeated automatic displays and `/continue ledger`.
- Inactive overlay focus-state copy/chrome.

## Validation

- `pnpm run gate` — pass; 217 tests passed, plus typecheck, JSON check, and pack check.
- `git diff --check` — pass.
- `printf '{"type":"get_commands"}\n' | pi --mode rpc --no-session --no-context-files --no-skills --no-extensions -e /Users/tiziano/Code/pi-continue` — pass; exposes only `continue`.
- `npm pack --dry-run --json --ignore-scripts` — pass; produced `pi-continue-0.9.0.tgz` candidate with 50 files, including `extensions/continue/src/key-input.ts`, excluding tests/ignored local runtime files.
- `npm view pi-continue version dist-tags.latest peerDependencies --json` — current public npm remains 0.8.2 before this release.

Publish auth note: `npm whoami` returned E401 in this agent shell. Per repo policy, npm publish remains user-owned and will require the user to authenticate/publish with OTP after the release commit/tag are pushed.
