### PR TITLE
[codex] Fix P2 review findings before 0.9.0 publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ All notable changes to `pi-continue` are documented here.
 ### Fixed
 
 - Allowed CSI-u Escape/Enter and key-identity shortcuts to close overlays and open `/continue` focus notes reliably, including layouts where the physical `f` shortcut does not decode as printable `f`.
+- Filtered modifier-only Kitty/CSI-u private-use input and Unicode non-characters out of focus notes while preserving normal Unicode text.
 - Added inactive overlay focus copy and dimmed chrome so users can tell when another panel owns keyboard focus.
+- Reported manual `/continue ledger` panel lifecycle failures with explicit UI warnings instead of silently accepting a failed overlay open.
 
 ## 0.8.2 - 2026-05-27
 

--- a/extensions/continue/src/key-input.ts
+++ b/extensions/continue/src/key-input.ts
@@ -54,6 +54,22 @@ const PALETTE_KEY_IDS: Record<PaletteKey, readonly KeyId[]> = {
 
 const CONTROL_CHAR_PATTERN = /[\u0000-\u001f\u007f-\u009f]/;
 
+function isPrivateUseCodePoint(codePoint: number): boolean {
+	return (codePoint >= 0xe000 && codePoint <= 0xf8ff)
+		|| (codePoint >= 0xf0000 && codePoint <= 0xffffd)
+		|| (codePoint >= 0x100000 && codePoint <= 0x10fffd);
+}
+
+function isNonCharacterCodePoint(codePoint: number): boolean {
+	return (codePoint >= 0xfdd0 && codePoint <= 0xfdef)
+		|| (codePoint >= 0xfffe && (codePoint & 0xfffe) === 0xfffe);
+}
+
+function isPrintableTextScalar(codePoint: number): boolean {
+	if (codePoint >= 0xd800 && codePoint <= 0xdfff) return false;
+	return !isPrivateUseCodePoint(codePoint) && !isNonCharacterCodePoint(codePoint);
+}
+
 function splitInput(data: string): string[] {
 	const buffer = new StdinBuffer({ timeout: 1_000 });
 	const events: string[] = [];
@@ -102,12 +118,18 @@ function isRawPrintableText(data: string): string | undefined {
 	if (data.length === 0) return undefined;
 	if (data.includes("\u001b")) return undefined;
 	if (CONTROL_CHAR_PATTERN.test(data)) return undefined;
+	for (const character of data) {
+		const codePoint = character.codePointAt(0);
+		if (codePoint === undefined || !isPrintableTextScalar(codePoint)) return undefined;
+	}
 	return data;
 }
 
 export function palettePrintableInput(data: string): string | undefined {
 	const direct = printableEvent(data);
 	if (direct !== undefined) return direct;
+	const rawDirect = isRawPrintableText(data);
+	if (rawDirect !== undefined) return rawDirect;
 	let output = "";
 	for (const event of splitInput(data)) {
 		const printable = printableEvent(event);

--- a/extensions/continue/src/ledger-viewer.ts
+++ b/extensions/continue/src/ledger-viewer.ts
@@ -23,7 +23,7 @@ interface TrackedLedgerOverlay {
 
 export interface ContinuationLedgerOverlayController {
 	clear(): void;
-	show(ctx: ExtensionContext, ledger: ContinuationLedgerSnapshot): Promise<boolean>;
+	show(ctx: ExtensionContext, ledger: ContinuationLedgerSnapshot, onLifecycleError?: () => void): Promise<boolean>;
 	showSoon(ctx: ExtensionContext, ledger: ContinuationLedgerSnapshot, onError: (reason: string) => void): void;
 }
 
@@ -140,7 +140,7 @@ export function createContinuationLedgerOverlayController(): ContinuationLedgerO
 		);
 		void lifecycle
 			.catch(() => {
-				if (activeLedgerOverlay === entry) onLifecycleError?.();
+				if (entry && activeLedgerOverlay === entry) onLifecycleError?.();
 			})
 			.finally(() => {
 				forgetLedgerOverlay(entry);
@@ -175,7 +175,15 @@ export async function showLatestContinuationLedger(
 		if (ctx.hasUI) ctx.ui.notify("No Continuation Ledger has been created in this session yet.", "warning");
 		return;
 	}
-	const shown = await overlay.show(ctx, ledger);
+	let shown = false;
+	try {
+		shown = await overlay.show(ctx, ledger, () => {
+			if (ctx.hasUI) ctx.ui.notify("Continuation Ledger could not open.", "warning");
+		});
+	} catch {
+		if (ctx.hasUI) ctx.ui.notify("Continuation Ledger could not open.", "warning");
+		return;
+	}
 	if (!shown && ctx.hasUI) {
 		ctx.ui.notify("Continuation Ledger cannot open in this Pi mode.", "warning");
 	}

--- a/tests/ledger-viewer.test.ts
+++ b/tests/ledger-viewer.test.ts
@@ -227,6 +227,27 @@ test("Continuation Ledger overlay fire-and-forget display reports open failures"
 	assert.deepEqual(reasons, ["Continuation Ledger could not open."]);
 });
 
+test("showLatestContinuationLedger reports manual overlay lifecycle failures", async () => {
+	const notifications = [];
+	const ctx = {
+		hasUI: true,
+		ui: {
+			custom(factory) {
+				factory({ requestRender() {} }, theme, {}, () => {});
+				return Promise.reject(new Error("open failed"));
+			},
+			notify(message, level) {
+				notifications.push({ message, level });
+			},
+		},
+	};
+	const overlay = createContinuationLedgerOverlayController();
+	await showLatestContinuationLedger(ctx, { eventId: "continue-1", compactionEntryId: "compact-1", content: "ledger", capturedAt: 0 }, overlay);
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.deepEqual(notifications, [{ message: "Continuation Ledger could not open.", level: "warning" }]);
+});
+
 test("ContinuationLedgerOverlay renders scrollable ledger panel", () => {
 	let closed = false;
 	let renders = 0;

--- a/tests/palette.test.ts
+++ b/tests/palette.test.ts
@@ -104,6 +104,8 @@ test("ContinuePaletteComponent keeps Unicode focus text and rejects CSI-u contro
 	}, () => {});
 	component.handleInput("f");
 	for (const char of "测试🙂é") component.handleInput(char);
+	component.handleInput("\u001b[57447;2u");
+	component.handleInput("\ufdd0");
 	component.handleInput("\u001b[133;1u");
 	component.handleInput("\u001b[9;1u");
 	component.handleInput("enter");


### PR DESCRIPTION
## Summary

Addresses the two Codex P2 review findings left on #6 before the 0.9.0 npm publish step:

- rejects modifier-only Kitty/CSI-u private-use input and Unicode non-characters from optional `/continue` focus notes while preserving normal Unicode text;
- reports manual `/continue ledger` overlay lifecycle failures with an explicit UI warning instead of silently accepting a failed panel open;
- updates the 0.9.0 changelog because these fixes are part of the unpublished release candidate.

This is a release-candidate correction on top of #6/#7. `pi-continue@0.9.0` is still not published to npm; after this lands, the `v0.9.0` source tag must point at the corrected release commit before the user-owned `npm publish` step.

## Validation

- `pnpm install --frozen-lockfile`
- `node --experimental-strip-types --test tests/palette.test.ts tests/ledger-viewer.test.ts tests/docs.test.ts`
- `pnpm run gate`
- `git diff --check`
- `printf '{"type":"get_commands"}\n' | pi --mode rpc --no-session --no-context-files --no-skills --no-extensions -e /Users/tiziano/Code/pi-continue`
- `npm pack --dry-run --json --ignore-scripts`

## Proof notes

- Command surface still exposes only `continue`.
- Pack dry-run remains `pi-continue@0.9.0` with 50 packaged files; tests, `.pi/`, local guides/notes, and ignored files remain excluded.
- Live interactive TUI smoke is still deferred; this PR has source, focused behavior tests, full gate, command-surface, package-candidate, 6 subagent review, and Grok review evidence.
