### PR TITLE
fix: keep resume working message visible

### DIFF
--- a/extensions/continue/index.ts
+++ b/extensions/continue/index.ts
@@ -156,21 +156,21 @@ export default function (pi: ExtensionAPI) {
 		if (event.prompt !== CONTINUATION_PROMPT) return;
 		const eventId = markAwaitingContinuationResumeStarted(runtime);
 		if (!eventId) return;
-		clearWorkingVisuals(ctx, runtime);
+		updateWorkingVisuals(ctx, runtime, eventId, "pi-continue resume running");
 	});
 
 	pi.on("message_start", async (event, ctx) => {
 		if (isContinuationPromptUserMessage(event.message, CONTINUATION_PROMPT)) {
 			const eventId = markAwaitingContinuationResumeStarted(runtime);
 			if (eventId) {
-				clearWorkingVisuals(ctx, runtime);
+				updateWorkingVisuals(ctx, runtime, eventId, "pi-continue resume running");
 			}
 			return;
 		}
 		if (!isAssistantMessage(event.message)) return;
 		const eventId = runtime.awaitingResumeEventId;
 		if (!eventId || runtime.latestEvent?.id !== eventId || runtime.latestEvent.resume.status !== "running") return;
-		clearWorkingVisuals(ctx, runtime);
+		updateWorkingVisuals(ctx, runtime, eventId, "pi-continue resume running");
 	});
 
 	pi.on("agent_end", async (_event, ctx) => {

--- a/tests/index-extension.test.ts
+++ b/tests/index-extension.test.ts
@@ -270,10 +270,10 @@ test("extension registers only /continue and exact RPC-style /continue falls thr
 	assert.deepEqual(ctx.statusCalls, []);
 	await pi.events.get("before_agent_start")({ prompt: CONTINUATION_PROMPT }, ctx);
 	assert.deepEqual(ctx.statusCalls, []);
-	assert.equal(ctx.workingMessages.at(-1), undefined);
+	assert.equal(ctx.workingMessages.at(-1), "pi-continue resume running");
 	await pi.events.get("message_start")({ message: assistantMessage() }, ctx);
 	assert.deepEqual(ctx.statusCalls, []);
-	assert.equal(ctx.workingMessages.at(-1), undefined);
+	assert.equal(ctx.workingMessages.at(-1), "pi-continue resume running");
 	await pi.commands.get("continue").handler(undefined, ctx);
 	assert.equal(ctx.compactCount, 1);
 	await pi.events.get("message_end")({ message: assistantMessage() }, ctx);
@@ -315,7 +315,7 @@ test("queued follow-up message_start starts same-session resume proof", async ()
 	assert.deepEqual(pi.sentOptions, [{ deliverAs: "followUp" }]);
 	await pi.events.get("message_start")({ message: userMessage(CONTINUATION_PROMPT) }, ctx);
 	assert.deepEqual(ctx.statusCalls, []);
-	assert.equal(ctx.workingMessages.at(-1), undefined);
+	assert.equal(ctx.workingMessages.at(-1), "pi-continue resume running");
 	await pi.events.get("message_end")({ message: assistantMessage() }, ctx);
 	assert.deepEqual(ctx.statusCalls, []);
 	assert.equal(ctx.workingMessages.at(-1), undefined);
@@ -368,7 +368,7 @@ test("mid-run guard chains when the resumed assistant tool loop fills context ag
 		await pi.events.get("session_compact")(ownedCompactionEvent(), ctx);
 		await pi.events.get("before_agent_start")({ prompt: CONTINUATION_PROMPT }, ctx);
 		await pi.events.get("message_end")({ message: highUsageAssistantMessage() }, ctx);
-		assert.equal(ctx.workingMessages.at(-1), undefined);
+		assert.equal(ctx.workingMessages.at(-1), "pi-continue resume running");
 		await pi.events.get("context")({
 			messages: [userMessage("continue tools"), highUsageAssistantMessage(), toolResultMessage("x".repeat(160))],
 		}, ctx);


### PR DESCRIPTION
## Summary

- restore the visible `pi-continue resume running` working message after same-session resume starts
- keep the v0.9.1 stable bullet indicator fix from #9 intact
- update existing extension lifecycle tests to cover direct, queued follow-up, and resumed tool-use flows

## Context

The v0.9.1 fix for #9 changed resume-start handling from updating the working message to clearing pi-continue's working visuals. That avoided the custom resume loader, but it also removed the phase-specific `pi-continue resume running` status entirely and could leave no pi-continue working prompt visible while the resumed turn is active.

This keeps the stable same-glyph bullet indicator from #9, but changes resume-start/message-start back to updating the working message instead of clearing it. Terminal settlement still clears the working visuals through the existing `message_end` / `agent_end` paths.

## Validation

- `npx --yes pnpm@latest run gate`
  - typecheck
  - 221 tests
  - JSON config check
  - npm pack dry-run
