### PR TITLE
Fix standalone Pi binary support

### DIFF
--- a/extensions/continue/src/pi-internals-local.ts
+++ b/extensions/continue/src/pi-internals-local.ts
@@ -1,0 +1,210 @@
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import type { FileOperations } from "./compaction-preparation.ts";
+import type { Context, PiInternals, Settings } from "./pi-internals.ts";
+
+type Api = typeof import("@earendil-works/pi-coding-agent");
+type Message = Parameters<Api["estimateTokens"]>[0];
+type Usage = Parameters<Api["calculateContextTokens"]>[0];
+type Project = (entry: SessionEntry) => unknown[];
+
+let host: Api;
+let project: Project | undefined;
+let acceptsZero = false;
+
+function configure(api: Api): void {
+	host = api;
+	project = (api as unknown as { sessionEntryToContextMessages?: Project }).sessionEntryToContextMessages;
+	acceptsZero = api.getLastAssistantUsage([{
+		type: "message",
+		id: "pi-continue-usage-probe",
+		parentId: null,
+		timestamp: "1970-01-01T00:00:00.000Z",
+		message: {
+			role: "assistant",
+			content: [],
+			provider: "pi-continue",
+			model: "usage-probe",
+			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+			stopReason: "stop",
+			timestamp: 0,
+		},
+	} as unknown as SessionEntry]) !== undefined;
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null ? value as Record<string, unknown> : undefined;
+}
+
+function usage(message: unknown): Usage | undefined {
+	const value = record(message);
+	if (!value || value.role !== "assistant" || value.stopReason === "aborted" || value.stopReason === "error") return undefined;
+	const data = record(value.usage) as Usage | undefined;
+	return data && (acceptsZero || host.calculateContextTokens(data) > 0) ? data : undefined;
+}
+
+function tokens(message: unknown): number {
+	return host.estimateTokens(message as Message);
+}
+
+function context(messages: unknown[]): Context {
+	let index = messages.length - 1;
+	while (index >= 0 && !usage(messages[index])) index--;
+	if (index < 0) {
+		let total = 0;
+		for (const message of messages) total += tokens(message);
+		return { tokens: total, usageTokens: 0, trailingTokens: total, lastUsageIndex: null };
+	}
+	const measured = usage(messages[index]);
+	if (!measured) throw new Error("Pi usage detection changed during context estimation");
+	const base = host.calculateContextTokens(measured);
+	let trailing = 0;
+	for (let current = index + 1; current < messages.length; current++) trailing += tokens(messages[current]);
+	return {
+		tokens: base + trailing,
+		usageTokens: base,
+		trailingTokens: trailing,
+		lastUsageIndex: index,
+	};
+}
+
+function time(value: unknown): number {
+	return new Date(value as string).getTime();
+}
+
+function custom(value: Record<string, unknown>): unknown {
+	return {
+		role: "custom",
+		customType: value.customType,
+		content: value.content,
+		display: value.display,
+		details: value.details,
+		timestamp: time(value.timestamp),
+	};
+}
+
+function branch(value: Record<string, unknown>): unknown | undefined {
+	if (typeof value.summary !== "string" || typeof value.fromId !== "string") return undefined;
+	return {
+		role: "branchSummary",
+		summary: value.summary,
+		fromId: value.fromId,
+		timestamp: time(value.timestamp),
+	};
+}
+
+function message(entry: SessionEntry): unknown | undefined {
+	const value = record(entry);
+	if (!value || value.type === "compaction") return undefined;
+	if (project) return project(entry)[0];
+	if (value.type === "message") return value.message;
+	if (value.type === "custom_message") return custom(value);
+	if (value.type === "branch_summary") return branch(value);
+	return undefined;
+}
+
+function paths(value: unknown, output: FileOperations): void {
+	const data = record(value);
+	if (!data || data.role !== "assistant" || !Array.isArray(data.content)) return;
+	for (const item of data.content) {
+		const block = record(item);
+		const args = record(block?.arguments);
+		const path = args?.path;
+		if (block?.type !== "toolCall" || typeof block.name !== "string" || typeof path !== "string" || path.length === 0) continue;
+		if (block.name === "read") output.read.add(path);
+		if (block.name === "write") output.written.add(path);
+		if (block.name === "edit") output.edited.add(path);
+	}
+}
+
+function add(values: unknown, output: Set<string>): void {
+	if (!Array.isArray(values)) return;
+	for (const value of values) output.add(value as string);
+}
+
+function prior(entries: SessionEntry[], index: number, output: FileOperations): void {
+	if (index < 0) return;
+	const entry = record(entries[index]);
+	if (!entry || entry.fromHook) return;
+	const details = record(entry.details);
+	if (!details) return;
+	add(details.readFiles, output.read);
+	add(details.modifiedFiles, output.edited);
+}
+
+function operations(messages: unknown[], entries: SessionEntry[], index: number): FileOperations {
+	const output: FileOperations = { read: new Set(), written: new Set(), edited: new Set() };
+	prior(entries, index, output);
+	for (const value of messages) paths(value, output);
+	return output;
+}
+
+interface Scope {
+	previous: number;
+	start: number;
+	summary?: string;
+}
+
+function scope(entries: SessionEntry[]): Scope | undefined {
+	let previous = -1;
+	for (let index = entries.length - 1; index >= 0; index--) {
+		if (record(entries[index])?.type !== "compaction") continue;
+		previous = index;
+		break;
+	}
+	if (previous < 0) return { previous, start: 0 };
+	const entry = record(entries[previous]);
+	if (!entry) return undefined;
+	const kept = entries.findIndex((item) => record(item)?.id === entry.firstKeptEntryId);
+	return {
+		previous,
+		start: kept >= 0 ? kept : previous + 1,
+		summary: typeof entry.summary === "string" ? entry.summary : undefined,
+	};
+}
+
+function collect(entries: SessionEntry[], start: number, end: number): unknown[] {
+	const output: unknown[] = [];
+	for (let index = start; index < end; index++) {
+		const value = message(entries[index]);
+		if (value) output.push(value);
+	}
+	return output;
+}
+
+function prepare(entries: unknown[], settings: Settings): unknown | undefined {
+	const path = entries as SessionEntry[];
+	if (record(path.at(-1))?.type === "compaction") return undefined;
+	const range = scope(path);
+	if (!range) return undefined;
+	const before = context(host.buildSessionContext(path).messages).tokens;
+	const cut = host.findCutPoint(path, range.start, path.length, settings.keepRecentTokens);
+	const first = record(path[cut.firstKeptEntryIndex]);
+	if (typeof first?.id !== "string" || first.id.length === 0) return undefined;
+	const history = cut.isSplitTurn ? cut.turnStartIndex : cut.firstKeptEntryIndex;
+	const messages = collect(path, range.start, history);
+	const prefix = cut.isSplitTurn ? collect(path, cut.turnStartIndex, cut.firstKeptEntryIndex) : [];
+	if (messages.length === 0 && prefix.length === 0 && !acceptsZero) return undefined;
+	const files = operations(messages, path, range.previous);
+	for (const value of prefix) paths(value, files);
+	return {
+		firstKeptEntryId: first.id,
+		messagesToSummarize: messages,
+		turnPrefixMessages: prefix,
+		isSplitTurn: cut.isSplitTurn,
+		tokensBefore: before,
+		previousSummary: range.summary,
+		fileOps: files,
+		settings,
+	};
+}
+
+export function createPiInternals(api: Api): PiInternals {
+	configure(api);
+	return {
+		prepareCompaction: prepare,
+		estimateTokens: tokens,
+		estimateContextTokens: context,
+		convertToLlm: (messages) => api.convertToLlm(messages as Parameters<Api["convertToLlm"]>[0]),
+		serializeConversation: (messages) => api.serializeConversation(messages as Parameters<Api["serializeConversation"]>[0]),
+	};
+}

--- a/extensions/continue/src/pi-internals.ts
+++ b/extensions/continue/src/pi-internals.ts
@@ -1,40 +1,32 @@
-import { dirname, join } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
-
-interface PiInternals {
-	prepareCompaction: (entries: unknown[], settings: { enabled: boolean; reserveTokens: number; keepRecentTokens: number }) => unknown;
+export interface PiInternals {
+	prepareCompaction: (entries: unknown[], settings: Settings) => unknown;
 	estimateTokens: (message: unknown) => number;
-	estimateContextTokens: (messages: unknown[]) => {
-		tokens: number;
-		usageTokens: number;
-		trailingTokens: number;
-		lastUsageIndex: number | null;
-	};
+	estimateContextTokens: (messages: unknown[]) => Context;
 	convertToLlm: (messages: unknown[]) => unknown[];
 	serializeConversation: (messages: unknown[]) => string;
 }
 
-let cachedInternals: Promise<PiInternals> | undefined;
+export interface Settings {
+	enabled: boolean;
+	reserveTokens: number;
+	keepRecentTokens: number;
+}
 
-/** Resolve Pi internal compaction helpers from the installed package at runtime. */
-export async function loadPiInternals(): Promise<PiInternals> {
-	if (!cachedInternals) {
-		cachedInternals = (async () => {
-			const packageEntryUrl = import.meta.resolve("@earendil-works/pi-coding-agent");
-			const distRoot = dirname(fileURLToPath(packageEntryUrl));
-			const [compactionModule, messagesModule, utilsModule] = await Promise.all([
-				import(pathToFileURL(join(distRoot, "core", "compaction", "compaction.js")).href),
-				import(pathToFileURL(join(distRoot, "core", "messages.js")).href),
-				import(pathToFileURL(join(distRoot, "core", "compaction", "utils.js")).href),
-			]);
-			return {
-				prepareCompaction: compactionModule.prepareCompaction,
-				estimateTokens: compactionModule.estimateTokens,
-				estimateContextTokens: compactionModule.estimateContextTokens,
-				convertToLlm: messagesModule.convertToLlm,
-				serializeConversation: utilsModule.serializeConversation,
-			};
-		})();
-	}
-	return cachedInternals;
+export interface Context {
+	tokens: number;
+	usageTokens: number;
+	trailingTokens: number;
+	lastUsageIndex: number | null;
+}
+
+const core = "@earendil-works/pi-coding-agent";
+const local = "./pi-internals-local.ts";
+let internals: Promise<PiInternals> | undefined;
+
+export function loadPiInternals(): Promise<PiInternals> {
+	internals ??= Promise.all([
+		import(core) as Promise<typeof import("@earendil-works/pi-coding-agent")>,
+		import(local) as Promise<typeof import("./pi-internals-local.ts")>,
+	]).then(([api, module]) => module.createPiInternals(api));
+	return internals;
 }

--- a/tests/pi-internals.test.ts
+++ b/tests/pi-internals.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { loadPiInternals } from "../extensions/continue/src/pi-internals.ts";
+
+const root = dirname(fileURLToPath(import.meta.resolve("@earendil-works/pi-coding-agent")));
+const native = await import(pathToFileURL(join(root, "core", "compaction", "compaction.js")).href);
+const settings = { enabled: true, reserveTokens: 16384, keepRecentTokens: 12 };
+const timestamp = "2026-07-25T12:00:00.000Z";
+
+function entry(id: string, parentId: string | null, message: unknown) {
+	return { type: "message", id, parentId, timestamp, message };
+}
+
+function user(text: string) {
+	return { role: "user", content: [{ type: "text", text }], timestamp };
+}
+
+function assistant(id: string, path: string) {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id, name: "read", arguments: { path } }],
+		provider: "openai-codex",
+		model: "gpt-5.4",
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+		stopReason: "toolUse",
+		timestamp,
+	};
+}
+
+function result(id: string, text: string) {
+	return {
+		role: "toolResult",
+		toolCallId: id,
+		toolName: "read",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp,
+	};
+}
+
+test("local token estimation matches Pi", async () => {
+	const local = await loadPiInternals();
+	const messages = [
+		user("before"),
+		{
+			role: "assistant",
+			content: [{ type: "text", text: "measured" }],
+			provider: "openai-codex",
+			model: "gpt-5.4",
+			usage: { input: 80, output: 20, cacheRead: 4, cacheWrite: 2, totalTokens: 106, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+			stopReason: "stop",
+			timestamp,
+		},
+		user("trailing context"),
+	];
+	assert.deepEqual(local.estimateContextTokens(messages), native.estimateContextTokens(messages));
+});
+
+test("local compaction preparation matches Pi for a completed tool batch", async () => {
+	const local = await loadPiInternals();
+	const entries = [
+		entry("u1", null, user("old context ".repeat(20))),
+		entry("a1", "u1", assistant("call-1", "/repo/old.ts")),
+		entry("r1", "a1", result("call-1", "old result ".repeat(20))),
+		entry("u2", "r1", user("recent request")),
+		entry("a2", "u2", assistant("call-2", "/repo/recent.ts")),
+		entry("r2", "a2", result("call-2", "recent result")),
+	];
+	assert.deepEqual(local.prepareCompaction(entries, settings), native.prepareCompaction(entries, settings));
+});
+
+test("local compaction preparation matches Pi after prior compaction", async () => {
+	const local = await loadPiInternals();
+	const entries = [
+		entry("u1", null, user("retired context ".repeat(20))),
+		entry("u2", "u1", user("kept context ".repeat(20))),
+		{
+			type: "compaction",
+			id: "c1",
+			parentId: "u2",
+			timestamp,
+			summary: "prior summary",
+			firstKeptEntryId: "u2",
+			tokensBefore: 200,
+			details: { readFiles: ["/repo/prior.ts"], modifiedFiles: ["/repo/changed.ts"] },
+		},
+		entry("u3", "c1", user("new context ".repeat(20))),
+		entry("a3", "u3", assistant("call-3", "/repo/new.ts")),
+		entry("r3", "a3", result("call-3", "new result")),
+	];
+	assert.deepEqual(local.prepareCompaction(entries, settings), native.prepareCompaction(entries, settings));
+});
+
+test("local no-op preparation follows the host Pi contract", async () => {
+	const local = await loadPiInternals();
+	const entries = [entry("u1", null, user("recent"))];
+	const config = { ...settings, keepRecentTokens: 20000 };
+	assert.deepEqual(local.prepareCompaction(entries, config), native.prepareCompaction(entries, config));
+});
+
+test("local preparation matches Pi for custom and branch entries", async () => {
+	const local = await loadPiInternals();
+	const entries = [
+		{ type: "custom_message", id: "c1", parentId: null, timestamp, customType: "fixture", content: "custom context", display: true },
+		{ type: "branch_summary", id: "b1", parentId: "c1", timestamp, summary: "branch context", fromId: "source" },
+		entry("u1", "b1", user("recent request")),
+	];
+	assert.deepEqual(local.prepareCompaction(entries, settings), native.prepareCompaction(entries, settings));
+});
+
+test("local preparation matches Pi null-content projection", async () => {
+	const local = await loadPiInternals();
+	const entries = [
+		entry("u1", null, { role: "user", content: null, timestamp }),
+		entry("u2", "u1", user("recent")),
+	];
+	const config = { ...settings, keepRecentTokens: 1 };
+	assert.deepEqual(local.prepareCompaction(entries, config), native.prepareCompaction(entries, config));
+});
+
+test("local preparation matches Pi migration and empty-path behavior", async () => {
+	const local = await loadPiInternals();
+	const missing = [entry("", null, user("missing id"))];
+	assert.deepEqual(local.prepareCompaction(missing, settings), native.prepareCompaction(missing, settings));
+	const entries = [
+		entry("u1", null, user("old context ".repeat(20))),
+		entry("a1", "u1", assistant("call-1", "")),
+		entry("r1", "a1", result("call-1", "result")),
+		entry("u2", "r1", user("recent")),
+	];
+	assert.deepEqual(local.prepareCompaction(entries, settings), native.prepareCompaction(entries, settings));
+});
+
+test("local helpers match Pi across generated linear histories", async () => {
+	const local = await loadPiInternals();
+	let seed = 0x5eed1234;
+	const random = (limit: number) => {
+		seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+		return seed % limit;
+	};
+	for (let sample = 0; sample < 100; sample++) {
+		const entries: unknown[] = [];
+		const messages: unknown[] = [];
+		let parent: string | null = null;
+		const turns = random(6) + 1;
+		for (let turn = 0; turn < turns; turn++) {
+			const uid = `u-${sample}-${turn}`;
+			const prompt = user("u".repeat(random(160) + 1));
+			entries.push(entry(uid, parent, prompt));
+			messages.push(prompt);
+			parent = uid;
+			const aid = `a-${sample}-${turn}`;
+			const call = `call-${sample}-${turn}`;
+			const tool = random(2) === 0;
+			const response = tool ? assistant(call, random(4) === 0 ? "" : `/repo/${sample}-${turn}.ts`) : {
+				role: "assistant",
+				content: [{ type: "text", text: "a".repeat(random(120) + 1) }],
+				provider: "openai-codex",
+				model: "gpt-5.4",
+				usage: { input: random(30), output: random(20), cacheRead: random(10), cacheWrite: random(5), totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+				stopReason: random(5) === 0 ? "error" : "stop",
+				timestamp,
+			};
+			entries.push(entry(aid, parent, response));
+			messages.push(response);
+			parent = aid;
+			if (!tool) continue;
+			const rid = `r-${sample}-${turn}`;
+			const output = result(call, "r".repeat(random(200) + 1));
+			entries.push(entry(rid, parent, output));
+			messages.push(output);
+			parent = rid;
+		}
+		const config = { ...settings, keepRecentTokens: random(120) };
+		assert.deepEqual(local.estimateContextTokens(messages), native.estimateContextTokens(messages), `token sample ${sample}`);
+		assert.deepEqual(local.prepareCompaction(entries, config), native.prepareCompaction(entries, config), `preparation sample ${sample}`);
+	}
+});


### PR DESCRIPTION
## Summary

- replace filesystem deep imports of Pi internals with lazy host-module loading
- preserve Pi 0.74 and 0.82 compaction semantics without runtime dependencies
- add differential tests against the installed Pi implementation

## Testing

- `npm run typecheck`
- `npm test` — 234 passed
- `npm run check:json`
- `npm run check:pack`
- dependency-free standalone probes on Pi 0.82.0 and 0.82.1: macOS arm64/x64 and Linux arm64
- full Node 26 gate in Linux arm64 and x64 containers

Fixes #12
