### PR TITLE
fix: keep automatic continuation across Pi compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `pi-continue` are documented here.
 
 ## Unreleased
 
+### Added
+
+- `adoptNativeCompaction` (default `true`) lets `pi-continue` own the over-threshold compaction Pi starts after a finished assistant turn, so end-of-turn automatic compaction also saves a Continuation Ledger and resumes the same session. Adoption requires Pi's own threshold trigger and the single checkpoint an ending turn opens: a `/compact` request, compaction while new user input is submitted, cancelled turns, and context-overflow recovery keep Pi's native summarizer, and an adopted checkpoint whose ledger cannot be built is handed back to Pi instead of cancelling the compaction. Set the key to `false` to keep every Pi-initiated compaction native.
+- `max` is now a selectable `reasoning` level, matching Pi's current thinking levels.
+
+### Fixed
+
+- Automatic continuation no longer stops contributing after Pi's own threshold compaction wins a checkpoint; previously those compactions were saved natively with no ledger and no resume.
+- Read a complete Continuation Ledger through model presentation wrappers such as Markdown fences, reasoning tags, and surrounding prose; the artifact must still satisfy the full v4 contract, and a response carrying competing artifacts still fails closed.
+- Retried modeled Continuation Ledger synthesis once with an explicit format reminder and reasoning disabled, so responses that answered with prose or spent the output budget on reasoning tokens no longer cancel the handoff.
+- Ignored unknown artifact keys and read an omitted or unexplained `agentGuideUpdate` as no replacement, so guide writes still require complete, explained model content.
+- Reported the bounded failure classifier with the handoff failure message, including a new classifier for responses truncated at the output token limit.
+- Reported the combined token usage and cost of both synthesis attempts instead of only the last one.
+- Let Pi's compaction operation own active-run cancellation, preventing a competing auto-compaction from causing a low-probability `Already compacted` handoff failure.
+- Kept one owner for the branch after that cancellation: Pi reads the run its own compaction operation stopped as an errored over-threshold turn and starts an automatic compaction of the same branch, so the automatic compaction is now cancelled while a package-owned request is in flight. Previously the two operations summarized the same branch in parallel, the package-owned request lost the save with `Compaction failed: Already compacted`, and the automatic continuation reported `handoff failed` even though the Continuation Ledger had been saved.
+- Resumed from a Continuation Ledger Pi already saved and reported for the active continuation when the package's own compaction request then fails, instead of settling a stored handoff as a failed continuation with no resume.
+- Kept `/compact` requests and context-overflow recovery with Pi's own summarizer by reading the compaction trigger Pi reports, so a bare `/compact` right after a finished assistant turn no longer claims the adoption checkpoint.
+
+### Changed
+
+- Requires Pi `0.81.0` or newer, the release that reports the compaction trigger (`reason`) to extensions and exposes the summarizer model's provider through `ctx.modelRegistry.getProvider()`; the package is developed and tested against Pi `0.84.3`.
+- Ran modeled Continuation Ledger synthesis through the summarizer model's own provider (`ctx.modelRegistry.getProvider(...).streamSimple(...)`) with resolved API key, headers, base URL, and provider environment, replacing the global `completeSimple` entry point Pi no longer exports. Provider-neutral reasoning levels are still mapped by Pi.
+
 ## 0.9.3 - 2026-07-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pi -e /absolute/path/to/pi-continue
 
 Pi packages run with your local user permissions. Review package source before installing third-party packages.
 
-Requires Pi `0.74.0` or newer, where model-specific thinking support is described by `thinkingLevelMap`.
+Requires Pi `0.81.0` or newer, the release that both reports the compaction trigger (`reason`) to extensions and exposes the summarizer model's provider through `ctx.modelRegistry.getProvider()`. Developed and tested against Pi `0.84.3`.
 
 ## Use `/continue`
 
@@ -70,6 +70,20 @@ It:
 - verifies Pi saved a package-owned `pi-continue/v4` compaction entry
 - sends the same-session resume prompt only after that proof
 
+Pi also runs its own compaction at the end of a turn, where this guard never sees the context. With `adoptNativeCompaction` enabled (the default), `pi-continue` owns that checkpoint too: it saves the Continuation Ledger for Pi's over-threshold compaction and resumes the same session after package-owned proof.
+
+Adoption requires Pi's own threshold trigger plus the single checkpoint opened when an assistant turn ends on its own, and only the first over-threshold compaction can claim it. These compactions stay with Pi's native summarizer:
+
+- a `/compact` request, instructed or not, because Pi reports it as a manual compaction
+- context-overflow recovery, which Pi retries itself
+- any compaction that does not directly follow a finished assistant turn, including one Pi runs while new user input is submitted, because that submission already drives the next turn
+- a cancelled turn
+- any adopted checkpoint whose ledger cannot be built; it is handed back to Pi instead of cancelling the compaction
+
+Set `adoptNativeCompaction` to `false` to keep every Pi-initiated compaction native.
+
+One handoff owns the branch at a time. A package-owned request stops the active run, and Pi can read that stopped run as its own reason to compact; while the package-owned request is in flight, `pi-continue` cancels the automatic compaction Pi starts on its own instead of letting both operations summarize the same branch. If another compaction, such as a `/compact` request, still saves the package-owned handoff first, `pi-continue` resumes from Pi's saved handoff proof rather than failing a continuation Pi already stored.
+
 The threshold belongs to Pi, not this package:
 
 ```text
@@ -96,7 +110,7 @@ Use `/continue status` after a continuation to see what happened. Status reports
 
 A model's context window and maximum output budget are independent. `pi-continue` derives the history budget from Pi's reserve-token setting or `historyMaxTokens`, then clamps the provider request to the selected summarizer model's positive max-output limit when that limit is known.
 
-If modeled Continuation Ledger creation fails, or if Pi reports native/invalid/mismatched compaction proof for an active continuation, `pi-continue` stops before resuming and writes no guessed continuation artifact or agent guide. Run `/continue status`, inspect the failure, use `/continue preview` after prompt or config changes, fix the model/auth/context issue, then retry when Pi is idle.
+A complete ledger is still read when the model wraps it in Markdown fences, reasoning tags, or surrounding prose, while a response carrying competing artifacts fails closed. When the first response is not usable, one retry runs with an explicit format reminder and reasoning disabled, so an answer that spent the output budget on reasoning tokens gets a second, full budget for the artifact. If modeled Continuation Ledger creation still fails, or if Pi reports native/invalid/mismatched compaction proof for an active continuation, `pi-continue` stops before resuming and writes no guessed continuation artifact or agent guide. Run `/continue status`, inspect the failure, use `/continue preview` after prompt or config changes, fix the model/auth/context issue, then retry when Pi is idle.
 
 ## Configuration
 
@@ -125,6 +139,7 @@ Default package config:
   "agentGuidePath": "AGENTS.md",
   "agentGuideSyncMode": "off",
   "midRunGuardEnabled": true,
+  "adoptNativeCompaction": true,
   "appendCompactionMetadata": false,
   "appendReadFileTags": false,
   "appendModifiedFileTags": true,
@@ -139,13 +154,14 @@ Common settings:
 | --- | --- |
 | `enabled` | Turns package behavior on or off. |
 | `midRunGuardEnabled` | Enables automatic mid-run continuation. |
+| `adoptNativeCompaction` | `true` by default; owns the over-threshold compaction Pi starts right after a finished assistant turn, so end-of-turn automatic compaction also saves a Continuation Ledger and resumes. `/compact` requests, compaction while new user input is submitted, cancelled turns, and context-overflow recovery keep Pi's own summarizer. |
 | `summarizerModel` | Uses the active Pi model with `"inherit"`, or a pinned `"provider/model"`. |
 | `reasoning` | Uses Pi's setting with `"inherit"`, or a model-supported thinking level. Unsupported levels are hidden in settings and clamped through Pi's `thinkingLevelMap`. |
 | `historyMaxTokens` | Optional requested history output-token budget; `null` uses Pi-derived default. The effective provider request is clamped to the summarizer model's positive max-output limit when known. |
-| `synthesisTimeoutMs` | Maximum time for the modeled Continuation Ledger pass before `pi-continue` cancels the handoff instead of leaving Pi in the native compacting loader. Default: `180000` ms. |
+| `synthesisTimeoutMs` | Maximum time for each modeled Continuation Ledger pass, including the single format-reminder retry, before `pi-continue` cancels the handoff instead of leaving Pi in the native compacting loader. Default: `180000` ms. |
 | `continuationArtifactMode` | `"always"` by default writes the rendered brief after successful package-owned compaction to `<project-root>/.pi/continue/<encoded-session-id>.md`; `"off"` disables that artifact. The artifact is human-inspection/manual-bootstrap output only and is never automatic prompt input. |
 | `agentGuidePath` | Repo-relative path for optional full guide replacement; default `"AGENTS.md"`. |
-| `agentGuideSyncMode` | `"off"` by default; `"always"` allows configured agent-guide replacement only when the artifact includes full guide content. |
+| `agentGuideSyncMode` | `"off"` by default; `"always"` allows configured agent-guide replacement only when the artifact includes full guide content and the reason for replacing it. |
 | `appendCompactionMetadata` | `false` by default; when true, appends compact non-path metadata to the compaction summary. |
 | `appendReadFileTags` | `false` by default; when true, appends current compaction read-file tags. |
 | `appendModifiedFileTags` | `true` by default; when true, appends current compaction modified-file tags. |
@@ -231,7 +247,7 @@ What can change:
 - `continuationArtifactMode: "off"` writes no continuation artifact.
 - `showAfterCompact: true` (default) surfaces the rendered brief in a TUI overlay right after compaction completes and reuses the latest panel for repeated displays; set `false` for a silent handoff.
 - `agentGuideSyncMode: "off"` is the default.
-- `agentGuideSyncMode: "always"` writes only a full non-null `agentGuideUpdate.content` replacement to the configured agent-guide path.
+- `agentGuideSyncMode: "always"` writes only a full non-null `agentGuideUpdate.content` replacement, paired with its `agentGuideUpdate.reason`, to the configured agent-guide path.
 - Writes are normalized and skipped when content is unchanged.
 
 In this repository, `.pi/`, `CONTINUE.md`, `PLAN.md`, `AGENTS.md`, `ARCH.md`, and `VISION.md` are ignored local state. The npm package keeps README as its only top-level operator guide; it still ships the changelog, examples, and prompt Markdown assets. Automatic AGENTS.md writes remain off by default.

--- a/examples/pi-continue.json
+++ b/examples/pi-continue.json
@@ -8,6 +8,7 @@
   "agentGuidePath": "AGENTS.md",
   "agentGuideSyncMode": "off",
   "midRunGuardEnabled": true,
+  "adoptNativeCompaction": true,
   "appendCompactionMetadata": false,
   "appendReadFileTags": false,
   "appendModifiedFileTags": true,

--- a/extensions/continue/index.ts
+++ b/extensions/continue/index.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, SessionBeforeCompactEvent } from "@earendil-works/pi-coding-agent";
 import { loadHistoryPromptAssets } from "./src/assets.ts";
 import { parseHistoryArtifacts } from "./src/blocks.ts";
 import { splitContinueSubcommand, shouldOpenContinuePalette } from "./src/command-shape.ts";
@@ -21,15 +21,15 @@ import {
 	recordContinuationSynthesisTelemetry,
 	recordOutputWriteResult,
 } from "./src/continuation-event.ts";
-import { buildContinuationDetails, buildContinuationSynthesisTelemetry, parseContinuationDetails } from "./src/details.ts";
-import { SYNTHESIS_ABORT_MESSAGE } from "./src/synthesis-error.ts";
+import { buildContinuationDetails, buildContinuationSynthesisTelemetry, combinePromptPassAttempts, parseContinuationDetails } from "./src/details.ts";
+import { describeSynthesisAbort } from "./src/synthesis-error.ts";
 import { buildLedgerSnapshot, createContinuationLedgerOverlayController } from "./src/ledger-viewer.ts";
-import { runMidRunGuard } from "./src/mid-run-guard.ts";
+import { decideAdoptedCompactionTrigger, runMidRunGuard } from "./src/mid-run-guard.ts";
 import { PromptPassError, runPromptPass } from "./src/model.ts";
 import { loadPiInternals } from "./src/pi-internals.ts";
-import { compileHistoryPrompt } from "./src/prompt.ts";
+import { compileHistoryPrompt, withArtifactRepairReminder } from "./src/prompt.ts";
 import { resolveProjectContext, writeNormalizedMarkdownFile } from "./src/project.ts";
-import { isContinuationPromptUserMessage } from "./src/prompt-dispatch.ts";
+import { isContinuationPromptUserMessage, sendContinuationPrompt } from "./src/prompt-dispatch.ts";
 import { showContinuePalette } from "./src/palette.ts";
 import {
 	CONTINUATION_PROMPT,
@@ -38,9 +38,16 @@ import {
 	createContinuationRuntimeState,
 	dispatchVerifiedContinuationResume,
 	failContinuationCompactionProof,
+	clearContinuationAdoptionCheckpoint,
+	consumeContinuationAdoptionCheckpoint,
 	failRunningAwaitingContinuationResume,
 	markAwaitingContinuationResumeStarted,
+	markContinuationCompactionComplete,
+	openContinuationAdoptionCheckpoint,
+	recordAssistantStopReason,
+	releaseAdoptedContinuationCompaction,
 	settleAwaitingContinuationResumeFromAssistant,
+	startAdoptedContinuationCompaction,
 	type ContinuationRuntimeState,
 	verifyContinuationCompactionProof,
 } from "./src/runtime.ts";
@@ -49,7 +56,7 @@ import {
 	NATIVE_COMPACTION_FALLBACK_FAILURE,
 	clearPendingResumeDispatch,
 } from "./src/resume-proof.ts";
-import type { AgentGuideWriteStatus, ContinuationSynthesisFailure, ContinuationSynthesisTelemetry, ParsedHistoryArtifacts, PendingOutputWrite, WriteMode } from "./src/types.ts";
+import type { AgentGuideWriteStatus, ContinuationSynthesisFailure, ContinuationSynthesisTelemetry, ParsedHistoryArtifacts, PendingOutputWrite, PromptPassTelemetry, WriteMode } from "./src/types.ts";
 import {
 	clearWorkingVisuals,
 	settleWorkingVisuals,
@@ -153,6 +160,8 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.on("before_agent_start", async (event, ctx) => {
+		// A new turn owns what happens next, so the previous checkpoint is no longer adoptable.
+		clearContinuationAdoptionCheckpoint(runtime);
 		if (event.prompt !== CONTINUATION_PROMPT) return;
 		const eventId = markAwaitingContinuationResumeStarted(runtime);
 		if (!eventId) return;
@@ -173,7 +182,14 @@ export default function (pi: ExtensionAPI) {
 		updateWorkingVisuals(ctx, runtime, eventId, "pi-continue resume running");
 	});
 
+	pi.on("input", async (_event, _ctx) => {
+		// New user input means the next compaction belongs to that submission, not to a
+		// finished assistant turn, so it must not be adopted as an automatic checkpoint.
+		clearContinuationAdoptionCheckpoint(runtime);
+	});
+
 	pi.on("agent_end", async (_event, ctx) => {
+		openContinuationAdoptionCheckpoint(runtime);
 		const settlement = failRunningAwaitingContinuationResume(runtime, "Continuation resume did not produce an assistant response.");
 		if (settlement) {
 			settleWorkingVisuals(ctx, runtime, settlement.eventId);
@@ -184,6 +200,7 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("message_end", async (event, ctx) => {
 		if (!isAssistantMessage(event.message)) return;
+		recordAssistantStopReason(runtime, event.message.stopReason);
 		const settlement = settleAwaitingContinuationResumeFromAssistant(runtime, event.message);
 		if (!settlement) return;
 		settleWorkingVisuals(ctx, runtime, settlement.eventId);
@@ -193,21 +210,53 @@ export default function (pi: ExtensionAPI) {
 		await runMidRunGuard(pi, ctx, runtime, event.messages, (eventId) => cleanupPendingOutputWrites(eventId));
 	});
 
-	pi.on("session_before_compact", async (event, ctx) => {
+	async function prepareCompactionHandoff(
+		event: SessionBeforeCompactEvent,
+		ctx: ExtensionContext,
+		ownership: { adoptedEventId?: string },
+	) {
 		const sessionId = ctx.sessionManager.getSessionId();
-		const ownerEventId = getActiveContinuationEventId(runtime);
-		if (ownerEventId === undefined) return undefined;
-		const ownerStillActive = () => isActiveRunningContinuationEvent(runtime, ownerEventId);
-		const ownerLostResult = () => ownerStillActive() ? undefined : { cancel: true as const };
+		const startedEventId = getActiveContinuationEventId(runtime);
 		const projectContext = await resolveProjectContext(pi, ctx.cwd, sessionId);
-		const ownerLostAfterProjectContext = ownerLostResult();
-		if (ownerLostAfterProjectContext) return ownerLostAfterProjectContext;
 		const config = loadContinuationConfig(projectContext.projectRoot);
-		if (!config.enabled) return { cancel: true };
+		if (!config.enabled) return startedEventId === undefined ? undefined : { cancel: true };
+		const normalizedPreparation = normalizeCompactionPreparation(event.preparation, event.branchEntries);
+		// Pi runs its own compaction at the end of a turn, where the mid-run guard never
+		// sees the context. Owning that over-threshold checkpoint keeps the ledger and the
+		// same-session resume instead of silently falling back to Pi's summarizer.
+		const adoptedTrigger = startedEventId === undefined
+			? decideAdoptedCompactionTrigger({
+				config,
+				piCompactionEnabled: normalizedPreparation.settings.enabled,
+				contextWindow: ctx.model?.contextWindow,
+				reserveTokens: normalizedPreparation.settings.reserveTokens,
+				tokensBefore: normalizedPreparation.tokensBefore,
+				checkpoint: consumeContinuationAdoptionCheckpoint(runtime),
+				reason: event.reason,
+				now: Date.now(),
+			})
+			: undefined;
+		const adoptedEventId = adoptedTrigger
+			? startAdoptedContinuationCompaction(ctx, runtime, {
+				trigger: adoptedTrigger,
+				continueAfterComplete: true,
+				sendContinuation: (prompt) => sendContinuationPrompt(pi, prompt),
+				onContinuationFailed: (eventId) => cleanupPendingOutputWrites(eventId),
+			})
+			: undefined;
+		const ownerEventId = startedEventId ?? adoptedEventId;
+		if (ownerEventId === undefined) return undefined;
+		const adopted = adoptedEventId !== undefined;
+		if (adopted) ownership.adoptedEventId = adoptedEventId;
+		const ownerStillActive = () => isActiveRunningContinuationEvent(runtime, ownerEventId);
+		// A lost owner must never return package details. An owned handoff fails closed; an
+		// adopted checkpoint is handed back to the compaction Pi decided to run.
+		const ownerLostResult = () => ownerStillActive()
+			? undefined
+			: { stop: true as const, result: adopted ? undefined : { cancel: true as const } };
 		const resolvedProjectContext = await resolveProjectContext(pi, ctx.cwd, sessionId, config.agentGuidePath);
 		const ownerLostAfterResolvedContext = ownerLostResult();
-		if (ownerLostAfterResolvedContext) return ownerLostAfterResolvedContext;
-		const normalizedPreparation = normalizeCompactionPreparation(event.preparation, event.branchEntries);
+		if (ownerLostAfterResolvedContext) return ownerLostAfterResolvedContext.result;
 		if (normalizedPreparation.repairedProviderUnsafeSuffix && ctx.hasUI) {
 			ctx.ui.notify("pi-continue summarized a provider-unsafe kept suffix before resuming.", "warning");
 		} else if (normalizedPreparation.repairedNoOpCut && ctx.hasUI) {
@@ -223,7 +272,7 @@ export default function (pi: ExtensionAPI) {
 		const fileOpsSnapshot = snapshotFileOperations(preparation.fileOps);
 		const internals = await loadPiInternals();
 		const ownerLostAfterInternals = ownerLostResult();
-		if (ownerLostAfterInternals) return ownerLostAfterInternals;
+		if (ownerLostAfterInternals) return ownerLostAfterInternals.result;
 		const messagesToSummarize = preparation.messagesToSummarize;
 		const turnPrefixMessages = preparation.turnPrefixMessages;
 		const turnPrefixTranscript = preparation.isSplitTurn && turnPrefixMessages.length > 0
@@ -250,29 +299,54 @@ export default function (pi: ExtensionAPI) {
 		let historyArtifacts: ParsedHistoryArtifacts;
 		let synthesis: ContinuationSynthesisTelemetry | undefined;
 		try {
-			const historyOutput = await runPromptPass(pi, ctx, config, historyPrompt, preparation.settings.reserveTokens, event.signal);
+			let attempt = await runPromptPass(pi, ctx, config, historyPrompt, preparation.settings.reserveTokens, event.signal);
 			const ownerLostAfterSynthesis = ownerLostResult();
-			if (ownerLostAfterSynthesis) return ownerLostAfterSynthesis;
-			synthesis = buildContinuationSynthesisTelemetry(historyOutput);
+			if (ownerLostAfterSynthesis) return ownerLostAfterSynthesis.result;
+			let passTelemetry: PromptPassTelemetry = attempt;
+			synthesis = buildContinuationSynthesisTelemetry(passTelemetry);
 			recordContinuationSynthesisTelemetry(runtime, ownerEventId, synthesis);
-			const parsedHistoryArtifacts = parseHistoryArtifacts(historyOutput.text);
+			let parsedHistoryArtifacts = parseHistoryArtifacts(attempt.text);
 			if (!parsedHistoryArtifacts.ok) {
+				// One bounded retry. Reminding the model of the artifact contract recovers
+				// prose answers and mixed wrappers, and disabling reasoning for the retry
+				// leaves the whole output budget for the artifact when the first attempt
+				// spent it on reasoning tokens.
+				attempt = await runPromptPass(
+					pi,
+					ctx,
+					{ ...config, reasoning: "off" },
+					withArtifactRepairReminder(historyPrompt),
+					preparation.settings.reserveTokens,
+					event.signal,
+				);
+				const ownerLostAfterRepair = ownerLostResult();
+				if (ownerLostAfterRepair) return ownerLostAfterRepair.result;
+				passTelemetry = combinePromptPassAttempts(passTelemetry, attempt);
+				synthesis = buildContinuationSynthesisTelemetry(passTelemetry);
+				recordContinuationSynthesisTelemetry(runtime, ownerEventId, synthesis);
+				parsedHistoryArtifacts = parseHistoryArtifacts(attempt.text);
+			}
+			if (!parsedHistoryArtifacts.ok) {
+				const truncated = attempt.stopReason === "length";
 				throw new ArtifactParseError({
-					kind: "artifact-parse-validation",
-					code: parsedHistoryArtifacts.code,
+					kind: truncated ? "model-provider-call" : "artifact-parse-validation",
+					code: truncated ? "provider-truncated" : parsedHistoryArtifacts.code,
 					pass: "history",
-					requestedModel: historyOutput.requestedModel,
-					httpStatus: historyOutput.httpStatus,
+					requestedModel: attempt.requestedModel,
+					httpStatus: attempt.httpStatus,
 				});
 			}
 			historyArtifacts = parsedHistoryArtifacts.artifacts;
 			markContinuationArtifact(runtime, ownerEventId, "modeled", undefined);
 		} catch (error) {
 			if (ownerStillActive()) {
-				recordContinuationSynthesisFailure(runtime, ownerEventId, normalizeSynthesisFailure(error));
-				markContinuationArtifact(runtime, ownerEventId, "aborted", SYNTHESIS_ABORT_MESSAGE);
+				const failure = normalizeSynthesisFailure(error);
+				recordContinuationSynthesisFailure(runtime, ownerEventId, failure);
+				markContinuationArtifact(runtime, ownerEventId, "aborted", describeSynthesisAbort(failure));
 			}
-			return { cancel: true };
+			if (!adopted) return { cancel: true };
+			releaseAdoptedContinuationCompaction(ctx, runtime, ownerEventId, (eventId) => cleanupPendingOutputWrites(eventId));
+			return undefined;
 		}
 		const continuationArtifactWriteId = config.continuationArtifactMode === "always" ? randomUUID() : undefined;
 		if (continuationArtifactWriteId) {
@@ -316,6 +390,9 @@ export default function (pi: ExtensionAPI) {
 			synthesis,
 			ownerEventId,
 		);
+		// Pi owns this compaction, so there is no package compact callback to report
+		// completion. Arming the proof gate here keeps resume behind Pi's saved entry.
+		if (adopted) markContinuationCompactionComplete(ctx, runtime, ownerEventId);
 		return {
 			compaction: {
 				summary: composeCompactionSummary(historyArtifacts.briefMarkdown, details, {
@@ -328,6 +405,34 @@ export default function (pi: ExtensionAPI) {
 				details,
 			},
 		};
+	}
+
+	let compactionHandoffInFlight = false;
+
+	pi.on("session_before_compact", async (event, ctx) => {
+		// One compaction at a time: a second operation entering while a handoff is being
+		// prepared is cancelled rather than allowed to summarize and save the same branch in
+		// parallel with it.
+		if (compactionHandoffInFlight) return { cancel: true };
+		// The package-owned request aborts the active run, and Pi reads that aborted turn as a
+		// reason to start its own threshold or overflow compaction. Both operations would then
+		// summarize the same branch, and whichever loses the save fails with "Already compacted".
+		// The package-owned request arrives as `manual` and stays the single owner until it settles.
+		if (runtime.compactionRunning && event.reason !== "manual") return { cancel: true };
+		compactionHandoffInFlight = true;
+		const ownership: { adoptedEventId?: string } = {};
+		try {
+			return await prepareCompactionHandoff(event, ctx, ownership);
+		} catch (error) {
+			// Pi swallows handler failures and continues with its own summarizer, so the event
+			// this handler adopted is released instead of waiting for proof that never arrives.
+			const adoptedEventId = ownership.adoptedEventId;
+			if (adoptedEventId === undefined || !isActiveRunningContinuationEvent(runtime, adoptedEventId)) throw error;
+			releaseAdoptedContinuationCompaction(ctx, runtime, adoptedEventId, (eventId) => cleanupPendingOutputWrites(eventId));
+			return undefined;
+		} finally {
+			compactionHandoffInFlight = false;
+		}
 	});
 
 	pi.on("session_compact", async (event, ctx) => {

--- a/extensions/continue/src/blocks.ts
+++ b/extensions/continue/src/blocks.ts
@@ -1,6 +1,8 @@
 import type { HistoryArtifactParseResult, ParsedHistoryArtifacts } from "./types.ts";
 
 const HISTORY_ARTIFACT_VERSION = "pi-continue-artifacts/v4";
+const NO_AGENT_GUIDE_REPLACEMENT_REASON = "The handoff model returned no agent guide replacement.";
+const UNEXPLAINED_AGENT_GUIDE_REPLACEMENT_REASON = "The handoff model returned an agent guide replacement without a reason, so no guide write was scheduled.";
 
 const ESTABLISHED_BASIS = new Set<string>([
 	"observed",
@@ -10,14 +12,11 @@ const ESTABLISHED_BASIS = new Set<string>([
 	"doc",
 ]);
 
-const HISTORY_ARTIFACT_KEYS = ["version", "brief", "agentGuideUpdate"] as const;
-const BRIEF_KEYS = ["task", "done_when", "forbid", "established", "learned", "open", "next"] as const;
-const FORBID_KEYS = ["rule", "source"] as const;
-const ESTABLISHED_KEYS = ["claim", "evidence", "basis", "reopen"] as const;
-const LEARNED_KEYS = ["lesson", "source"] as const;
-const OPEN_KEYS = ["question", "verifies"] as const;
-const NEXT_KEYS = ["action", "outcome"] as const;
-const AGENT_GUIDE_UPDATE_KEYS = ["content", "reason"] as const;
+// Presentation wrappers commonly added around the JSON artifact by chat and
+// local reasoning models. Candidates extracted from them are still validated
+// against the full v4 contract before any of them is accepted.
+const REASONING_BLOCK_PATTERN = /<(think|thinking|reasoning|reflection)>[\s\S]*?<\/\1>/gi;
+const FENCED_BLOCK_PATTERN = /(?:^|\r?\n)[ \t]*(?:`{3,}|~{3,})[^\r\n]*\r?\n([\s\S]*?)\r?\n[ \t]*(?:`{3,}|~{3,})[ \t]*(?=\r?\n|$)/g;
 
 interface ForbidEntry {
 	rule: string;
@@ -56,6 +55,11 @@ interface BriefEnvelope {
 	next: NextEntry[];
 }
 
+interface AgentGuideUpdate {
+	content: string | undefined;
+	reason: string;
+}
+
 function escapeTag(tag: string): string {
 	return tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -64,21 +68,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function hasExactKeys(value: Record<string, unknown>, expectedKeys: readonly string[]): boolean {
-	const keys = Object.keys(value);
-	if (keys.length !== expectedKeys.length) return false;
-	const expected = new Set<string>(expectedKeys);
-	return keys.every((key) => expected.has(key));
-}
-
 function nonEmptyString(value: unknown): string | undefined {
 	if (typeof value !== "string") return undefined;
 	const trimmed = value.trim();
 	return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function nullableString(value: unknown): string | undefined {
-	return value === null ? undefined : nonEmptyString(value);
 }
 
 // Collapse any newlines and embedded markdown bullet markers in a per-entry field
@@ -96,8 +89,66 @@ function singleLineString(value: unknown): string | undefined {
 	return collapsed.length > 0 ? collapsed : undefined;
 }
 
+/** Collect every balanced top-level JSON object embedded in model output. */
+function collectJsonObjectCandidates(text: string): string[] {
+	const candidates: string[] = [];
+	let depth = 0;
+	let start = -1;
+	let inString = false;
+	let escaped = false;
+	for (let index = 0; index < text.length; index += 1) {
+		const character = text[index];
+		if (inString) {
+			if (escaped) escaped = false;
+			else if (character === "\\") escaped = true;
+			else if (character === '"') inString = false;
+			continue;
+		}
+		if (character === '"') {
+			inString = true;
+			continue;
+		}
+		if (character === "{") {
+			if (depth === 0) start = index;
+			depth += 1;
+			continue;
+		}
+		if (character !== "}" || depth === 0) continue;
+		depth -= 1;
+		if (depth === 0 && start >= 0) {
+			candidates.push(text.slice(start, index + 1));
+			start = -1;
+		}
+	}
+	return candidates;
+}
+
+/**
+ * Order the artifact payloads worth validating for one model response.
+ *
+ * The strict v4 contract still decides what is usable: this only looks past
+ * presentation wrappers (reasoning tags, Markdown fences, surrounding prose)
+ * that models add around an otherwise complete artifact.
+ */
+function artifactCandidates(text: string): string[] {
+	const ordered: string[] = [];
+	const seen = new Set<string>();
+	const add = (value: string): void => {
+		const trimmed = value.trim();
+		if (trimmed.length === 0 || seen.has(trimmed)) return;
+		seen.add(trimmed);
+		ordered.push(trimmed);
+	};
+	add(text);
+	const withoutReasoning = text.replace(REASONING_BLOCK_PATTERN, "\n");
+	add(withoutReasoning);
+	for (const match of withoutReasoning.matchAll(FENCED_BLOCK_PATTERN)) add(match[1]);
+	for (const candidate of collectJsonObjectCandidates(withoutReasoning)) add(candidate);
+	return ordered;
+}
+
 function parseForbidEntry(value: unknown): ForbidEntry | undefined {
-	if (!isRecord(value) || !hasExactKeys(value, FORBID_KEYS)) return undefined;
+	if (!isRecord(value)) return undefined;
 	const rule = singleLineString(value.rule);
 	const source = singleLineString(value.source);
 	if (!rule || !source) return undefined;
@@ -105,7 +156,7 @@ function parseForbidEntry(value: unknown): ForbidEntry | undefined {
 }
 
 function parseEstablishedEntry(value: unknown): EstablishedEntry | undefined {
-	if (!isRecord(value) || !hasExactKeys(value, ESTABLISHED_KEYS)) return undefined;
+	if (!isRecord(value)) return undefined;
 	const claim = singleLineString(value.claim);
 	const evidence = singleLineString(value.evidence);
 	const basis = singleLineString(value.basis);
@@ -116,7 +167,7 @@ function parseEstablishedEntry(value: unknown): EstablishedEntry | undefined {
 }
 
 function parseLearnedEntry(value: unknown): LearnedEntry | undefined {
-	if (!isRecord(value) || !hasExactKeys(value, LEARNED_KEYS)) return undefined;
+	if (!isRecord(value)) return undefined;
 	const lesson = singleLineString(value.lesson);
 	const source = singleLineString(value.source);
 	if (!lesson || !source) return undefined;
@@ -124,7 +175,7 @@ function parseLearnedEntry(value: unknown): LearnedEntry | undefined {
 }
 
 function parseOpenEntry(value: unknown): OpenEntry | undefined {
-	if (!isRecord(value) || !hasExactKeys(value, OPEN_KEYS)) return undefined;
+	if (!isRecord(value)) return undefined;
 	const question = singleLineString(value.question);
 	const verifies = singleLineString(value.verifies);
 	if (!question || !verifies) return undefined;
@@ -132,14 +183,16 @@ function parseOpenEntry(value: unknown): OpenEntry | undefined {
 }
 
 function parseNextEntry(value: unknown): NextEntry | undefined {
-	if (!isRecord(value) || !hasExactKeys(value, NEXT_KEYS)) return undefined;
+	if (!isRecord(value)) return undefined;
 	const action = singleLineString(value.action);
 	const outcome = singleLineString(value.outcome);
 	if (!action || !outcome) return undefined;
 	return { action, outcome };
 }
 
-function parseEntryArray<T>(value: unknown, parseEntry: (entry: unknown) => T | undefined): T[] | undefined {
+// Every brief slot must be present. An empty list is a valid statement about a
+// slot; an absent list is an incomplete ledger the receiver cannot trust.
+function parseEntryList<T>(value: unknown, parseEntry: (entry: unknown) => T | undefined): T[] | undefined {
 	if (!Array.isArray(value)) return undefined;
 	const result: T[] = [];
 	for (const entry of value) {
@@ -151,17 +204,29 @@ function parseEntryArray<T>(value: unknown, parseEntry: (entry: unknown) => T | 
 }
 
 function parseBriefEnvelope(value: unknown): BriefEnvelope | undefined {
-	if (!isRecord(value) || !hasExactKeys(value, BRIEF_KEYS)) return undefined;
+	if (!isRecord(value)) return undefined;
 	const task = singleLineString(value.task);
 	const done_when = singleLineString(value.done_when);
 	if (!task || !done_when) return undefined;
-	const forbid = parseEntryArray(value.forbid, parseForbidEntry);
-	const established = parseEntryArray(value.established, parseEstablishedEntry);
-	const learned = parseEntryArray(value.learned, parseLearnedEntry);
-	const open = parseEntryArray(value.open, parseOpenEntry);
-	const next = parseEntryArray(value.next, parseNextEntry);
+	const forbid = parseEntryList(value.forbid, parseForbidEntry);
+	const established = parseEntryList(value.established, parseEstablishedEntry);
+	const learned = parseEntryList(value.learned, parseLearnedEntry);
+	const open = parseEntryList(value.open, parseOpenEntry);
+	const next = parseEntryList(value.next, parseNextEntry);
 	if (!forbid || !established || !learned || !open || !next) return undefined;
 	return { task, done_when, forbid, established, learned, open, next };
+}
+
+// The guide is a file the package owns, so it is only ever rewritten from a
+// complete replacement the model both provided and explained. Anything less is
+// read as "no replacement" instead of discarding the whole ledger.
+function parseAgentGuideUpdate(value: unknown): AgentGuideUpdate | undefined {
+	if (value === undefined || value === null) return { content: undefined, reason: NO_AGENT_GUIDE_REPLACEMENT_REASON };
+	if (!isRecord(value)) return undefined;
+	const content = nonEmptyString(value.content);
+	const reason = nonEmptyString(value.reason);
+	if (content && !reason) return { content: undefined, reason: UNEXPLAINED_AGENT_GUIDE_REPLACEMENT_REASON };
+	return { content, reason: reason ?? NO_AGENT_GUIDE_REPLACEMENT_REASON };
 }
 
 function renderEntrySection<T>(title: string, entries: T[], renderEntry: (entry: T) => string): string | undefined {
@@ -202,6 +267,20 @@ function renderBriefEnvelope(brief: BriefEnvelope): string {
 	return sections.join("\n\n");
 }
 
+function readHistoryArtifacts(parsed: unknown): ParsedHistoryArtifacts | undefined {
+	if (!isRecord(parsed)) return undefined;
+	if (parsed.version !== HISTORY_ARTIFACT_VERSION) return undefined;
+	const brief = parseBriefEnvelope(parsed.brief);
+	if (!brief) return undefined;
+	const agentGuideUpdate = parseAgentGuideUpdate(parsed.agentGuideUpdate);
+	if (!agentGuideUpdate) return undefined;
+	return {
+		briefMarkdown: renderBriefEnvelope(brief),
+		agentGuideMd: agentGuideUpdate.content,
+		agentGuideChangeReason: agentGuideUpdate.reason,
+	};
+}
+
 /** Extract the first XML-style tagged block from model output. */
 export function extractTaggedBlock(text: string, tag: string): string | undefined {
 	const pattern = new RegExp(`<${escapeTag(tag)}>([\\s\\S]*?)</${escapeTag(tag)}>`, "i");
@@ -214,29 +293,25 @@ export function extractTaggedBlock(text: string, tag: string): string | undefine
 export function parseHistoryArtifacts(text: string): HistoryArtifactParseResult {
 	const trimmed = text.trim();
 	if (trimmed.length === 0) return { ok: false, code: "artifact-empty" };
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(trimmed);
-	} catch (error) {
-		if (error instanceof SyntaxError) return { ok: false, code: "artifact-invalid-json" };
-		throw error;
+	let sawJsonObject = false;
+	const accepted = new Map<string, ParsedHistoryArtifacts>();
+	for (const candidate of artifactCandidates(trimmed)) {
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(candidate);
+		} catch (error) {
+			if (error instanceof SyntaxError) continue;
+			throw error;
+		}
+		if (!isRecord(parsed)) continue;
+		sawJsonObject = true;
+		const artifacts = readHistoryArtifacts(parsed);
+		if (artifacts) accepted.set(JSON.stringify(artifacts), artifacts);
 	}
-	if (!isRecord(parsed) || !hasExactKeys(parsed, HISTORY_ARTIFACT_KEYS)) return { ok: false, code: "artifact-invalid-shape" };
-	if (parsed.version !== HISTORY_ARTIFACT_VERSION) return { ok: false, code: "artifact-invalid-shape" };
-	const brief = parseBriefEnvelope(parsed.brief);
-	if (!brief) return { ok: false, code: "artifact-invalid-shape" };
-	if (!isRecord(parsed.agentGuideUpdate) || !hasExactKeys(parsed.agentGuideUpdate, AGENT_GUIDE_UPDATE_KEYS)) return { ok: false, code: "artifact-invalid-shape" };
-	const rawContent = parsed.agentGuideUpdate.content;
-	if (rawContent !== null && nonEmptyString(rawContent) === undefined) return { ok: false, code: "artifact-invalid-shape" };
-	const agentGuideMd = rawContent === null ? undefined : nullableString(rawContent);
-	const agentGuideChangeReason = nonEmptyString(parsed.agentGuideUpdate.reason);
-	if (!agentGuideChangeReason) return { ok: false, code: "artifact-invalid-shape" };
-	return {
-		ok: true,
-		artifacts: {
-			briefMarkdown: renderBriefEnvelope(brief),
-			agentGuideMd,
-			agentGuideChangeReason,
-		},
-	};
+	// One response must identify one handoff. Repeated copies of the same artifact
+	// are the same handoff; competing artifacts are not, so they fail closed
+	// instead of letting document order pick the receiver's memory.
+	if (accepted.size === 1) return { ok: true, artifacts: [...accepted.values()][0] };
+	if (accepted.size > 1) return { ok: false, code: "artifact-ambiguous" };
+	return { ok: false, code: sawJsonObject ? "artifact-invalid-shape" : "artifact-invalid-json" };
 }

--- a/extensions/continue/src/commands.ts
+++ b/extensions/continue/src/commands.ts
@@ -101,7 +101,7 @@ async function chooseModel(ctx: ExtensionCommandContext): Promise<string | undef
 	return selected;
 }
 
-const ALL_REASONING_OPTIONS: readonly ContinuationConfig["reasoning"][] = ["inherit", "off", "minimal", "low", "medium", "high", "xhigh"];
+const ALL_REASONING_OPTIONS: readonly ContinuationConfig["reasoning"][] = ["inherit", "off", "minimal", "low", "medium", "high", "xhigh", "max"];
 
 /** Return operator-selectable reasoning levels, hiding levels unsupported by the resolved summarizer model. */
 export function getReasoningOptionsForModel(model: Model<Api> | undefined): ContinuationConfig["reasoning"][] {

--- a/extensions/continue/src/config.ts
+++ b/extensions/continue/src/config.ts
@@ -18,6 +18,7 @@ const REASONING_LEVELS = new Set<ContinuationReasoning>([
 	"medium",
 	"high",
 	"xhigh",
+	"max",
 ]);
 const PROMPT_OVERRIDE_POLICIES = new Set<PromptOverridePolicy>([
 	"package-default",
@@ -49,6 +50,7 @@ export const DEFAULT_CONTINUE_CONFIG: ContinuationConfig = {
 	agentGuidePath: "AGENTS.md",
 	agentGuideSyncMode: "off",
 	midRunGuardEnabled: true,
+	adoptNativeCompaction: true,
 	appendCompactionMetadata: false,
 	appendReadFileTags: false,
 	appendModifiedFileTags: true,
@@ -66,6 +68,7 @@ interface PartialContinuationConfig {
 	agentGuidePath?: string;
 	agentGuideSyncMode?: string;
 	midRunGuardEnabled?: boolean;
+	adoptNativeCompaction?: boolean;
 	appendCompactionMetadata?: boolean;
 	appendReadFileTags?: boolean;
 	appendModifiedFileTags?: boolean;
@@ -83,6 +86,7 @@ export interface ContinuationConfigPatch {
 	agentGuidePath?: string;
 	agentGuideSyncMode?: WriteMode;
 	midRunGuardEnabled?: boolean;
+	adoptNativeCompaction?: boolean;
 	appendCompactionMetadata?: boolean;
 	appendReadFileTags?: boolean;
 	appendModifiedFileTags?: boolean;
@@ -132,6 +136,8 @@ function parsePartialConfig(value: unknown): PartialContinuationConfig {
 	if (agentGuideSyncMode !== undefined) result.agentGuideSyncMode = agentGuideSyncMode;
 	const midRunGuardEnabled = asBoolean(value.midRunGuardEnabled);
 	if (midRunGuardEnabled !== undefined) result.midRunGuardEnabled = midRunGuardEnabled;
+	const adoptNativeCompaction = asBoolean(value.adoptNativeCompaction);
+	if (adoptNativeCompaction !== undefined) result.adoptNativeCompaction = adoptNativeCompaction;
 	const appendCompactionMetadata = asBoolean(value.appendCompactionMetadata);
 	if (appendCompactionMetadata !== undefined) result.appendCompactionMetadata = appendCompactionMetadata;
 	const appendReadFileTags = asBoolean(value.appendReadFileTags);
@@ -203,6 +209,7 @@ function normalizeConfig(partial: PartialContinuationConfig): ContinuationConfig
 		agentGuidePath: normalizePath(partial.agentGuidePath, DEFAULT_CONTINUE_CONFIG.agentGuidePath),
 		agentGuideSyncMode: normalizeWriteMode(partial.agentGuideSyncMode, DEFAULT_CONTINUE_CONFIG.agentGuideSyncMode),
 		midRunGuardEnabled: partial.midRunGuardEnabled ?? DEFAULT_CONTINUE_CONFIG.midRunGuardEnabled,
+		adoptNativeCompaction: partial.adoptNativeCompaction ?? DEFAULT_CONTINUE_CONFIG.adoptNativeCompaction,
 		appendCompactionMetadata: partial.appendCompactionMetadata ?? DEFAULT_CONTINUE_CONFIG.appendCompactionMetadata,
 		appendReadFileTags: partial.appendReadFileTags ?? DEFAULT_CONTINUE_CONFIG.appendReadFileTags,
 		appendModifiedFileTags: partial.appendModifiedFileTags ?? DEFAULT_CONTINUE_CONFIG.appendModifiedFileTags,

--- a/extensions/continue/src/details.ts
+++ b/extensions/continue/src/details.ts
@@ -187,6 +187,25 @@ function clonePromptPassTelemetry(telemetry: PromptPassTelemetry | undefined): P
 	};
 }
 
+/** Fold an extra synthesis attempt into the reported pass usage so retries are not under-reported. */
+export function combinePromptPassAttempts(
+	previous: PromptPassTelemetry | undefined,
+	latest: PromptPassTelemetry,
+): PromptPassTelemetry {
+	if (!previous) return latest;
+	return {
+		...latest,
+		usage: {
+			input: previous.usage.input + latest.usage.input,
+			output: previous.usage.output + latest.usage.output,
+			cacheRead: previous.usage.cacheRead + latest.usage.cacheRead,
+			cacheWrite: previous.usage.cacheWrite + latest.usage.cacheWrite,
+			totalTokens: previous.usage.totalTokens + latest.usage.totalTokens,
+			costTotal: previous.usage.costTotal + latest.usage.costTotal,
+		},
+	};
+}
+
 export function buildContinuationSynthesisTelemetry(
 	history: PromptPassTelemetry | undefined,
 ): ContinuationSynthesisTelemetry | undefined {

--- a/extensions/continue/src/mid-run-guard.ts
+++ b/extensions/continue/src/mid-run-guard.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, SessionBeforeCompactEvent } from "@earendil-works/pi-coding-agent";
 import { loadContinuationConfig } from "./config.ts";
 import { normalizeCompactionPreparation, type ContinuationCompactionPreparation } from "./compaction-preparation.ts";
 import { readEffectivePiCompactionSettings } from "./pi-settings.ts";
@@ -9,6 +9,7 @@ import { startContinuationCompaction, type ContinuationRuntimeState } from "./ru
 import { endsWithCompleteToolResultBatch } from "./tool-batches.ts";
 import type {
 	ContextUsageEstimateSnapshot,
+	ContinuationAdoptionCheckpoint,
 	ContinuationConfig,
 	MidRunGuardTrigger,
 	PiCompactionSettings,
@@ -162,6 +163,56 @@ export function decideMidRunGuardTrigger(input: MidRunGuardDecisionInput): MidRu
 		usageTokens: input.estimate.usageTokens,
 		trailingTokens: input.estimate.trailingTokens,
 		lastUsageIndex: input.estimate.lastUsageIndex,
+	};
+}
+
+/** Stop reasons that mean the assistant finished its own turn rather than erroring or being cancelled. */
+const ADOPTABLE_STOP_REASONS = new Set<string>(["stop", "toolUse", "length"]);
+/** Pi starts its threshold compaction inside the same agent_end processing as the checkpoint. */
+export const ADOPTION_CHECKPOINT_MAX_AGE_MS = 5_000;
+
+export interface AdoptedCompactionDecisionInput {
+	config: ContinuationConfig;
+	piCompactionEnabled: boolean;
+	/** What Pi reported as the trigger of this compaction. */
+	reason: SessionBeforeCompactEvent["reason"];
+	contextWindow: number | undefined;
+	reserveTokens: number;
+	tokensBefore: number;
+	/** Single-use checkpoint already claimed by this compaction, if one was open. */
+	checkpoint: ContinuationAdoptionCheckpoint | undefined;
+	now: number;
+}
+
+/**
+ * Decide whether a compaction Pi started on its own is the automatic
+ * over-threshold checkpoint the package should own.
+ *
+ * Adoption requires Pi's own threshold trigger plus the single-use checkpoint
+ * opened by an assistant turn that ended on its own. A `/compact` request and
+ * context-overflow recovery report their own trigger, and new user input, a new
+ * turn, or an earlier compaction closes the checkpoint, so all of them keep Pi's
+ * native summarizer.
+ */
+export function decideAdoptedCompactionTrigger(input: AdoptedCompactionDecisionInput): MidRunGuardTrigger | undefined {
+	if (!input.config.enabled || !input.config.adoptNativeCompaction) return undefined;
+	if (!input.piCompactionEnabled || input.reason !== "threshold") return undefined;
+	if (!hasUsableContextWindow(input.contextWindow, input.reserveTokens)) return undefined;
+	if (!isFiniteNumber(input.tokensBefore)) return undefined;
+	const checkpoint = input.checkpoint;
+	if (!checkpoint) return undefined;
+	if (input.now - checkpoint.openedAt > ADOPTION_CHECKPOINT_MAX_AGE_MS) return undefined;
+	if (checkpoint.stopReason === undefined || !ADOPTABLE_STOP_REASONS.has(checkpoint.stopReason)) return undefined;
+	const thresholdTokens = input.contextWindow - input.reserveTokens;
+	if (input.tokensBefore <= thresholdTokens) return undefined;
+	return {
+		estimatedTokens: input.tokensBefore,
+		thresholdTokens,
+		contextWindow: input.contextWindow,
+		reserveTokens: input.reserveTokens,
+		usageTokens: input.tokensBefore,
+		trailingTokens: 0,
+		lastUsageIndex: null,
 	};
 }
 

--- a/extensions/continue/src/model.ts
+++ b/extensions/continue/src/model.ts
@@ -1,5 +1,5 @@
-import type { Api, Model, ModelThinkingLevel, ThinkingLevel } from "@earendil-works/pi-ai";
-import { clampThinkingLevel, completeSimple } from "@earendil-works/pi-ai";
+import type { Api, AssistantMessage, Model, ModelThinkingLevel, SimpleStreamOptions, StopReason, ThinkingLevel } from "@earendil-works/pi-ai";
+import { clampThinkingLevel } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { resolveHistoryOutputBudget, resolveSummarizerModel } from "./model-settings.ts";
 import type { ContinuationConfig, ContinuationSynthesisFailureCode, PromptPassTelemetry } from "./types.ts";
@@ -8,6 +8,8 @@ export { resolveHistoryOutputBudget, resolveSummarizerModel } from "./model-sett
 
 export interface PromptPassResult extends PromptPassTelemetry {
 	text: string;
+	/** Provider stop reason for the pass; `length` means the artifact was cut off by the output budget. */
+	stopReason: StopReason;
 }
 
 export class PromptPassError extends Error {
@@ -80,6 +82,12 @@ export async function runPromptPass(
 	}
 	const requestedModel = `${model.provider}/${model.id}`;
 	const outputBudget = resolveHistoryOutputBudget(model, reserveTokens, config.historyMaxTokens);
+	// The provider owns the request: `streamSimple` maps one provider-neutral reasoning
+	// level onto each API's own thinking parameters.
+	const provider = ctx.modelRegistry.getProvider(model.provider);
+	if (!provider) {
+		throw new PromptPassError("model-unresolved", { requestedModel });
+	}
 	let auth: Awaited<ReturnType<ExtensionContext["modelRegistry"]["getApiKeyAndHeaders"]>>;
 	try {
 		auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
@@ -91,11 +99,22 @@ export async function runPromptPass(
 	}
 	const reasoning = resolveReasoningLevel(pi, model, config);
 	let httpStatus: number | undefined;
-	let response: Awaited<ReturnType<typeof completeSimple>>;
+	let response: AssistantMessage;
 	const promptPassAbort = createPromptPassAbortSignal(signal, config.synthesisTimeoutMs);
+	const requestOptions: SimpleStreamOptions = {
+		apiKey: auth.apiKey,
+		headers: auth.headers,
+		env: auth.env,
+		maxTokens: outputBudget.effectiveTokens,
+		signal: promptPassAbort.signal,
+		onResponse: (providerResponse) => {
+			httpStatus = providerResponse.status;
+		},
+	};
+	if (reasoning) requestOptions.reasoning = reasoning;
 	try {
-		response = await completeSimple(
-			model,
+		response = await provider.streamSimple(
+			auth.baseUrl ? { ...model, baseUrl: auth.baseUrl } : model,
 			{
 				systemPrompt: prompt.systemPrompt,
 				messages: [
@@ -106,27 +125,8 @@ export async function runPromptPass(
 					},
 				],
 			},
-			reasoning
-				? {
-						apiKey: auth.apiKey,
-						headers: auth.headers,
-						maxTokens: outputBudget.effectiveTokens,
-						reasoning,
-						signal: promptPassAbort.signal,
-						onResponse: (providerResponse) => {
-							httpStatus = providerResponse.status;
-						},
-					}
-				: {
-						apiKey: auth.apiKey,
-						headers: auth.headers,
-						maxTokens: outputBudget.effectiveTokens,
-						signal: promptPassAbort.signal,
-						onResponse: (providerResponse) => {
-							httpStatus = providerResponse.status;
-						},
-					},
-		);
+			requestOptions,
+		).result();
 	} catch {
 		throw new PromptPassError(providerAbortCode(signal, promptPassAbort), { requestedModel, httpStatus });
 	} finally {
@@ -146,6 +146,7 @@ export async function runPromptPass(
 		.trim();
 	return {
 		text,
+		stopReason: response.stopReason,
 		requestedModel,
 		responseModel: response.responseModel,
 		responseId: response.responseId,

--- a/extensions/continue/src/prompt.ts
+++ b/extensions/continue/src/prompt.ts
@@ -48,6 +48,20 @@ export function compileHistoryPrompt(assets: HistoryPromptAssets, input: History
 	};
 }
 
+/** Retry reminder for models that answer the artifact contract with prose or partial JSON. */
+export const ARTIFACT_REPAIR_REMINDER = [
+	"<artifact-format-retry>",
+	"The previous response could not be read as the required artifact.",
+	"Return only the JSON object defined by the contract above: no prose, no Markdown fences, no reasoning tags, no XML wrapper.",
+	"The response must start with { and end with }.",
+	"</artifact-format-retry>",
+].join("\n");
+
+/** Append the retry reminder to an already compiled history prompt. */
+export function withArtifactRepairReminder(prompt: CompiledPrompt): CompiledPrompt {
+	return { ...prompt, userPrompt: `${prompt.userPrompt}\n\n${ARTIFACT_REPAIR_REMINDER}` };
+}
+
 /** Render a human-readable prompt preview for the settings and preview commands. */
 export function renderPromptPreview(title: string, prompt: CompiledPrompt): string {
 	const parts = [

--- a/extensions/continue/src/runtime.ts
+++ b/extensions/continue/src/runtime.ts
@@ -12,8 +12,10 @@ import {
 import type {
 	ContinuationEventSource,
 	ContinuationLatestEvent,
+	ContinuationAdoptionCheckpoint,
 	ContinuationLedgerSnapshot,
 	ContinuationResumeStatus,
+	ContinuationTurnProvenance,
 	MidRunGuardTrigger,
 } from "./types.ts";
 import {
@@ -30,12 +32,12 @@ import {
 } from "./working-ui.ts";
 
 export { CONTINUATION_PROMPT } from "./continuation-prompt.ts";
-export { acceptContinuationCompactionProof, armDeferredResumeStartTimeout, clearResumeStartTimeout, dispatchVerifiedContinuationResume, failContinuationCompactionProof, verifyContinuationCompactionProof } from "./resume-proof.ts";
+export { acceptContinuationCompactionProof, armDeferredResumeStartTimeout, clearResumeStartTimeout, dispatchVerifiedContinuationResume, failContinuationCompactionProof, markContinuationCompactionComplete, verifyContinuationCompactionProof } from "./resume-proof.ts";
 
 export type ContinuationRequestMode = "steer" | "queue";
 export type ContinuationRequestSource = ContinuationEventSource;
 
-export interface ContinuationRuntimeState extends ResumeProofRuntimeState {
+export interface ContinuationRuntimeState extends ResumeProofRuntimeState, ContinuationTurnProvenance {
 	latestLedger: ContinuationLedgerSnapshot | undefined;
 	lastNoCompactableGuardKey: string | undefined;
 }
@@ -109,6 +111,8 @@ export function createContinuationRuntimeState(): ContinuationRuntimeState {
 		pendingResumeDispatch: undefined,
 		latestLedger: undefined,
 		lastNoCompactableGuardKey: undefined,
+		adoptionCheckpoint: undefined,
+		lastAssistantStopReason: undefined,
 		latestEvent: undefined,
 		activeEventId: undefined,
 		nextEventSequence: 0,
@@ -149,9 +153,10 @@ export function buildGuardInstructions(trigger: MidRunGuardTrigger): string {
 	].join("\n");
 }
 
-function sourceLabel(source: ContinuationRequestSource): string {
+function sourceLabel(source: ContinuationEventSource): string {
 	if (source === "command-queue") return "queued /continue";
 	if (source === "command-steer") return "/continue steer";
+	if (source === "adopted-compaction") return "adopted automatic compaction";
 	return "automatic continuation";
 }
 
@@ -195,6 +200,12 @@ function compactionFailureReason(runtime: ContinuationRuntimeState, eventId: str
 	return COMPACTION_FAILURE;
 }
 
+/** Whether Pi already saved and reported this event's package-owned handoff entry. */
+function hasVerifiedCompactionProof(runtime: ContinuationRuntimeState, eventId: string): boolean {
+	const event = runtime.latestEvent;
+	return event?.id === eventId && event.compactionProof.status === "verified";
+}
+
 /** Start the package-owned compaction pipeline once, with visible lifecycle settlement. */
 export function startContinuationCompaction(
 	ctx: ExtensionContext,
@@ -235,7 +246,11 @@ export function startContinuationCompaction(
 		options.continueAfterComplete ? "pending" : "not-requested",
 	);
 	beginWorkingVisuals(ctx, runtime, event.id, "pi-continue saving handoff");
-	if (options.abortActiveRun) ctx.abort();
+	// Pi's ctx.compact() aborts the active operation before it prepares the compaction.
+	// Calling ctx.abort() first lets Pi's automatic compaction race the package-owned
+	// request and can leave the latter with an "Already compacted" error, so this pipeline
+	// has one abort owner: ctx.compact(). The compaction Pi may still start from that
+	// aborted turn is cancelled in the session_before_compact handler.
 	const label = sourceLabel(options.source);
 	const triggerText = options.trigger ? ` (${describeGuardTrigger(options.trigger)})` : "";
 	notify(ctx, `${label}: saving handoff${triggerText}.`, "info");
@@ -271,23 +286,35 @@ export function startContinuationCompaction(
 		settleWorkingVisuals(ctx, runtime, event.id);
 		notify(ctx, `${label}: handoff failed: ${reason}`, "error");
 	}
+	function completeCompaction(): void {
+		runtime.compactionRunning = false;
+		runtime.guardFailureKey = undefined;
+		if (options.continueAfterComplete) {
+			markContinuationCompactionComplete(ctx, runtime, event.id);
+			return;
+		}
+		finishContinuationEvent(runtime, event.id, "completed", undefined);
+		settleWorkingVisuals(ctx, runtime, event.id);
+		notify(ctx, `${label}: handoff saved.`, "info");
+	}
 	try {
 		ctx.compact({
 			customInstructions,
 			onComplete: () => {
 				if (!claimCompactionCallback()) return;
-				runtime.compactionRunning = false;
-				runtime.guardFailureKey = undefined;
-				if (options.continueAfterComplete) {
-					markContinuationCompactionComplete(ctx, runtime, event.id);
-					return;
-				}
-				finishContinuationEvent(runtime, event.id, "completed", undefined);
-				settleWorkingVisuals(ctx, runtime, event.id);
-				notify(ctx, `${label}: handoff saved.`, "info");
+				completeCompaction();
 			},
 			onError: () => {
 				if (!claimCompactionCallback()) return;
+				// A concurrent compaction can save this event's package-owned handoff before Pi
+				// runs the package's own request, which then fails with "Already compacted".
+				// Pi's saved and reported entry is the handoff, so the resume follows that proof
+				// instead of failing a handoff Pi already stored.
+				if (hasVerifiedCompactionProof(runtime, event.id)) {
+					notify(ctx, `${label}: another compaction already saved this handoff.`, "warning");
+					completeCompaction();
+					return;
+				}
 				failCompaction(compactionFailureReason(runtime, event.id));
 			},
 		});
@@ -296,6 +323,98 @@ export function startContinuationCompaction(
 		return false;
 	}
 	return true;
+}
+
+/** Record the stop reason of the assistant response that just finished. */
+export function recordAssistantStopReason(runtime: ContinuationRuntimeState, stopReason: string | undefined): void {
+	runtime.lastAssistantStopReason = stopReason;
+}
+
+/** Open the single adoptable checkpoint for the assistant turn that just ended. */
+export function openContinuationAdoptionCheckpoint(runtime: ContinuationRuntimeState): void {
+	runtime.adoptionCheckpoint = { stopReason: runtime.lastAssistantStopReason, openedAt: Date.now() };
+}
+
+/** Close the checkpoint because new user input or a new turn owns what happens next. */
+export function clearContinuationAdoptionCheckpoint(runtime: ContinuationRuntimeState): void {
+	runtime.adoptionCheckpoint = undefined;
+}
+
+/** Claim the checkpoint for at most one compaction, so a later compaction cannot reuse it. */
+export function consumeContinuationAdoptionCheckpoint(runtime: ContinuationRuntimeState): ContinuationAdoptionCheckpoint | undefined {
+	const checkpoint = runtime.adoptionCheckpoint;
+	runtime.adoptionCheckpoint = undefined;
+	return checkpoint;
+}
+
+export interface AdoptedContinuationCompactionOptions {
+	trigger: MidRunGuardTrigger;
+	continueAfterComplete: boolean;
+	sendContinuation: (prompt: string) => void;
+	onContinuationFailed?: (eventId: string) => void;
+	resumeStartTimeoutMs?: number;
+	compactionProofTimeoutMs?: number;
+}
+
+/**
+ * Take ownership of an over-threshold compaction Pi started on its own.
+ *
+ * Pi runs its automatic compaction at the end of a turn, where the package's
+ * mid-run guard never sees the context. Without adoption those checkpoints fall
+ * back to Pi's own summarizer and the session continues without a ledger or a
+ * same-session resume.
+ */
+export function startAdoptedContinuationCompaction(
+	ctx: ExtensionContext,
+	runtime: ContinuationRuntimeState,
+	options: AdoptedContinuationCompactionOptions,
+): string | undefined {
+	clearStaleAwaitingContinuationResume(runtime);
+	if (runtime.compactionRunning || hasActiveContinuationSettlement(runtime)) return undefined;
+	const event = beginContinuationEvent(
+		runtime,
+		"adopted-compaction",
+		options.trigger,
+		options.continueAfterComplete ? "pending" : "not-requested",
+	);
+	beginWorkingVisuals(ctx, runtime, event.id, "pi-continue saving handoff");
+	const label = sourceLabel("adopted-compaction");
+	notify(ctx, `${label}: saving handoff (${describeGuardTrigger(options.trigger)}).`, "info");
+	if (options.continueAfterComplete) {
+		preparePendingResumeDispatch(runtime, {
+			eventId: event.id,
+			label,
+			sendContinuation: options.sendContinuation,
+			onContinuationFailed: options.onContinuationFailed,
+			resumeStartTimeoutMs: options.resumeStartTimeoutMs ?? RESUME_START_TIMEOUT_MS,
+			compactionProofTimeoutMs: options.compactionProofTimeoutMs ?? RESUME_START_TIMEOUT_MS,
+			failureGuardKey: undefined,
+		});
+	}
+	return event.id;
+}
+
+/**
+ * Hand an adopted compaction back to Pi when the package could not build a usable handoff.
+ *
+ * Only state that still belongs to this event is cleared: a stale caller whose owner was
+ * already settled must not disturb a newer continuation.
+ */
+export function releaseAdoptedContinuationCompaction(
+	ctx: ExtensionContext,
+	runtime: ContinuationRuntimeState,
+	eventId: string,
+	onContinuationFailed?: (eventId: string) => void,
+): void {
+	if (!isActiveRunningContinuationEvent(runtime, eventId)) return;
+	const reason = compactionFailureReason(runtime, eventId);
+	onContinuationFailed?.(eventId);
+	if (runtime.pendingResumeDispatch?.eventId === eventId) clearPendingResumeDispatch(runtime);
+	if (runtime.awaitingResumeStart?.eventId === eventId) clearResumeStartTimeout(runtime);
+	if (runtime.awaitingResumeEventId === eventId) runtime.awaitingResumeEventId = undefined;
+	if (!finishContinuationEvent(runtime, eventId, "failed", reason)) return;
+	settleWorkingVisuals(ctx, runtime, eventId);
+	notify(ctx, `${sourceLabel("adopted-compaction")}: handoff failed: ${reason} Pi kept its own compaction.`, "warning");
 }
 
 export function markAwaitingContinuationResumeStarted(runtime: ContinuationRuntimeState): string | undefined {

--- a/extensions/continue/src/status.ts
+++ b/extensions/continue/src/status.ts
@@ -1,6 +1,7 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { resolveHistoryOutputBudget, resolveSummarizerModel } from "./model-settings.ts";
 import { readEffectivePiCompactionSettings } from "./pi-settings.ts";
+import { synthesisFailureLabel } from "./synthesis-error.ts";
 import type {
 	ContinuationConfig,
 	ContinuationLatestEvent,
@@ -57,6 +58,7 @@ function formatTimestamp(value: number | undefined): string {
 
 function sourceLabel(event: ContinuationLatestEvent): string {
 	if (event.source === "mid-run-guard") return "automatic continuation";
+	if (event.source === "adopted-compaction") return "adopted automatic compaction";
 	if (event.source === "command-queue") return "queued /continue";
 	return "/continue steer";
 }
@@ -104,6 +106,7 @@ function renderTrigger(event: ContinuationLatestEvent): string {
 
 function renderSafeBoundary(event: ContinuationLatestEvent): string {
 	if (event.source === "mid-run-guard") return "completed assistant/tool-result batch before the next model request";
+	if (event.source === "adopted-compaction") return "Pi's own over-threshold compaction checkpoint";
 	if (event.source === "command-queue") return "waited until Pi was idle before saving the handoff";
 	return "requested by user; the current assistant turn stops first when needed";
 }
@@ -163,18 +166,6 @@ function renderPassTelemetry(label: string, telemetry: PromptPassTelemetry | und
 	return `- ${label}: requested ${telemetry.requestedModel}${routed}; ${telemetry.usage.totalTokens.toLocaleString()} tokens; ${formatCost(telemetry.usage.costTotal)}${http}${outputBudget}`;
 }
 
-function failureCodeLabel(failure: ContinuationSynthesisFailure): string {
-	if (failure.code === "model-unresolved") return "model unresolved";
-	if (failure.code === "auth-unavailable") return "auth unavailable";
-	if (failure.code === "provider-error") return "provider error";
-	if (failure.code === "provider-aborted") return "provider aborted";
-	if (failure.code === "provider-timeout") return "provider timeout";
-	if (failure.code === "artifact-empty") return "empty artifact";
-	if (failure.code === "artifact-invalid-json") return "invalid JSON";
-	if (failure.code === "artifact-invalid-shape") return "artifact did not match the current v4 JSON contract";
-	return "internal error";
-}
-
 function renderSynthesisFailure(failure: ContinuationSynthesisFailure): string {
 	const kind = failure.kind === "model-provider-call"
 		? "model/provider call failed"
@@ -183,7 +174,7 @@ function renderSynthesisFailure(failure: ContinuationSynthesisFailure): string {
 			: "internal synthesis failure";
 	const requested = failure.requestedModel ? `; requested ${failure.requestedModel}` : "";
 	const http = failure.httpStatus !== undefined ? `; HTTP ${failure.httpStatus}` : "";
-	return `- Synthesis failure: ${kind} during ${failure.pass} pass (${failureCodeLabel(failure)})${requested}${http}.`;
+	return `- Synthesis failure: ${kind} during ${failure.pass} pass (${synthesisFailureLabel(failure.code)})${requested}${http}.`;
 }
 
 function renderSynthesisSummary(event: ContinuationLatestEvent): string[] {
@@ -274,6 +265,7 @@ export function renderStatus(
 		`- Agent guide updates: ${config.agentGuideSyncMode}`,
 		`- Agent guide writes: ${config.agentGuideSyncMode === "always" ? "full replacement only" : "off"}`,
 		`- Automatic mid-run continuation: ${config.midRunGuardEnabled ? "yes" : "no"}`,
+		`- Adopt Pi's over-threshold compaction: ${config.adoptNativeCompaction ? "yes" : "no"}`,
 		`- Append compaction metadata: ${config.appendCompactionMetadata ? "yes" : "no"}`,
 		`- Append read file tags: ${config.appendReadFileTags ? "yes" : "no"}`,
 		`- Append modified file tags: ${config.appendModifiedFileTags ? "yes" : "no"}`,

--- a/extensions/continue/src/synthesis-error.ts
+++ b/extensions/continue/src/synthesis-error.ts
@@ -1,1 +1,27 @@
+import type { ContinuationSynthesisFailure, ContinuationSynthesisFailureCode } from "./types.ts";
+
 export const SYNTHESIS_ABORT_MESSAGE = "pi-continue could not create a usable handoff, so continuation stopped before resuming.";
+
+const FAILURE_CODE_LABELS: Record<ContinuationSynthesisFailureCode, string> = {
+	"model-unresolved": "model unresolved",
+	"auth-unavailable": "auth unavailable",
+	"provider-error": "provider error",
+	"provider-aborted": "provider aborted",
+	"provider-timeout": "provider timeout",
+	"provider-truncated": "response stopped at the output token limit before the artifact was complete",
+	"artifact-empty": "empty artifact",
+	"artifact-invalid-json": "invalid JSON",
+	"artifact-invalid-shape": "artifact did not match the current v4 JSON contract",
+	"artifact-ambiguous": "response contained more than one candidate artifact",
+	"internal-error": "internal error",
+};
+
+/** Bounded package-owned label for a synthesis failure classifier. */
+export function synthesisFailureLabel(code: ContinuationSynthesisFailureCode): string {
+	return FAILURE_CODE_LABELS[code] ?? FAILURE_CODE_LABELS["internal-error"];
+}
+
+/** Fixed hard-fail copy plus the bounded classifier, so a failed handoff is actionable without /continue status. */
+export function describeSynthesisAbort(failure: ContinuationSynthesisFailure): string {
+	return `${SYNTHESIS_ABORT_MESSAGE} Cause: ${synthesisFailureLabel(failure.code)}.`;
+}

--- a/extensions/continue/src/types.ts
+++ b/extensions/continue/src/types.ts
@@ -1,11 +1,7 @@
-export type ContinuationReasoning =
-	| "inherit"
-	| "off"
-	| "minimal"
-	| "low"
-	| "medium"
-	| "high"
-	| "xhigh";
+import type { ModelThinkingLevel } from "@earendil-works/pi-ai";
+
+/** Pi's thinking levels, plus the sentinel that follows Pi's current level. */
+export type ContinuationReasoning = "inherit" | ModelThinkingLevel;
 
 export type PromptOverridePolicy = "package-default" | "global-override" | "project-override";
 export type WriteMode = "always" | "off";
@@ -22,6 +18,7 @@ export interface ContinuationConfig {
 	agentGuidePath: string;
 	agentGuideSyncMode: WriteMode;
 	midRunGuardEnabled: boolean;
+	adoptNativeCompaction: boolean;
 	appendCompactionMetadata: boolean;
 	appendReadFileTags: boolean;
 	appendModifiedFileTags: boolean;
@@ -80,7 +77,7 @@ export interface ParsedHistoryArtifacts {
 	agentGuideChangeReason: string;
 }
 
-export type ContinuationEventSource = "command-steer" | "command-queue" | "mid-run-guard";
+export type ContinuationEventSource = "command-steer" | "command-queue" | "mid-run-guard" | "adopted-compaction";
 export type ContinuationEventStatus = "running" | "completed" | "failed" | "blocked";
 export type ContinuationArtifactStatus = "pending" | "modeled" | "aborted";
 export type ContinuationPromptStatus = "pending" | "sent" | "not-requested" | "failed";
@@ -93,9 +90,11 @@ export type ContinuationSynthesisFailureCode =
 	| "provider-error"
 	| "provider-aborted"
 	| "provider-timeout"
+	| "provider-truncated"
 	| "artifact-empty"
 	| "artifact-invalid-json"
 	| "artifact-invalid-shape"
+	| "artifact-ambiguous"
 	| "internal-error";
 export type ContinuationWriteStatus = "off" | "pending" | "updated" | "unchanged" | "failed" | "no-replacement";
 export type ContinuationOutputWriteTarget = "continuation-artifact" | "agent-guide";
@@ -108,7 +107,7 @@ export interface HistoryOutputBudget {
 	clampedByModel: boolean;
 }
 
-export type HistoryArtifactParseFailureCode = "artifact-empty" | "artifact-invalid-json" | "artifact-invalid-shape";
+export type HistoryArtifactParseFailureCode = "artifact-empty" | "artifact-invalid-json" | "artifact-invalid-shape" | "artifact-ambiguous";
 
 export type HistoryArtifactParseResult =
 	| { ok: true; artifacts: ParsedHistoryArtifacts }
@@ -242,6 +241,24 @@ export interface ContextUsageEstimateSnapshot {
 	usageTokens: number;
 	trailingTokens: number;
 	lastUsageIndex: number | null;
+}
+
+/** One adoptable checkpoint opened by an assistant turn that ended on its own. */
+export interface ContinuationAdoptionCheckpoint {
+	stopReason: string | undefined;
+	openedAt: number;
+}
+
+/**
+ * Local record of how the session reached the current checkpoint.
+ *
+ * Pi's `session_before_compact` event does not say why Pi started compacting, so
+ * adoption is gated on a single-use checkpoint opened when an assistant turn ends
+ * and closed by new user input, a new turn, or the first compaction that claims it.
+ */
+export interface ContinuationTurnProvenance {
+	adoptionCheckpoint: ContinuationAdoptionCheckpoint | undefined;
+	lastAssistantStopReason: string | undefined;
 }
 
 export interface MidRunGuardTrigger {

--- a/package.json
+++ b/package.json
@@ -37,16 +37,16 @@
     "extensions/"
   ],
   "scripts": {
-    "test": "node --experimental-strip-types --test tests/*.test.ts",
+    "test": "node --experimental-strip-types --test --test-timeout=60000 tests/*.test.ts",
     "typecheck": "tsc --noEmit",
     "check:json": "node -e \"const fs=require('node:fs'); for (const f of ['package.json', ...fs.readdirSync('examples').filter((name) => name.endsWith('.json')).map((name) => 'examples/' + name)]) JSON.parse(fs.readFileSync(f, 'utf8'));\"",
     "check:pack": "npm pack --dry-run --json --ignore-scripts >/dev/null",
     "gate": "pnpm run typecheck && pnpm test && pnpm run check:json && pnpm run check:pack"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": ">=0.74.0",
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
-    "@earendil-works/pi-tui": ">=0.74.0"
+    "@earendil-works/pi-ai": ">=0.81.0",
+    "@earendil-works/pi-coding-agent": ">=0.81.0",
+    "@earendil-works/pi-tui": ">=0.81.0"
   },
   "pi": {
     "extensions": [
@@ -55,9 +55,9 @@
     "image": "https://raw.githubusercontent.com/Tiziano-AI/pi-continue/v0.9.3/assets/gallery/pi-continue-gallery.webp"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.74.0",
-    "@earendil-works/pi-coding-agent": "^0.74.0",
-    "@earendil-works/pi-tui": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.84.3",
+    "@earendil-works/pi-coding-agent": "^0.84.3",
+    "@earendil-works/pi-tui": "^0.84.3",
     "@types/node": "^25.6.1",
     "typescript": "^6.0.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     devDependencies:
       '@earendil-works/pi-ai':
-        specifier: ^0.74.0
-        version: 0.74.0(ws@8.20.0)(zod@4.4.3)
+        specifier: ^0.84.3
+        version: 0.84.3(supports-color@7.2.0)(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.74.0
-        version: 0.74.0(ws@8.20.0)(zod@4.4.3)
+        specifier: ^0.84.3
+        version: 0.84.3(supports-color@7.2.0)(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.74.0
-        version: 0.74.0
+        specifier: ^0.84.3
+        version: 0.84.3
       '@types/node':
         specifier: ^25.6.1
         version: 25.6.1
@@ -35,10 +35,6 @@ packages:
       zod:
         optional: true
 
-  '@aws-crypto/crc32@5.2.0':
-    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
-    engines: {node: '>=16.0.0'}
-
   '@aws-crypto/sha256-browser@5.2.0':
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
 
@@ -52,162 +48,127 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-bedrock-runtime@3.1044.0':
-    resolution: {integrity: sha512-uwJB0pVZIey+kYag8xeUirMvuaDhhEHuYgSsapOKT5XCAije5pLNlg160eECJdhX9JEf0IthIM3IiHKSEkFtMw==}
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.974.8':
-    resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.34':
-    resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.36':
-    resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.38':
-    resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.38':
-    resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.39':
-    resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
+  '@aws-sdk/credential-provider-node@3.972.81':
+    resolution: {integrity: sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.34':
-    resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.38':
-    resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.38':
-    resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/eventstream-handler-node@3.972.14':
-    resolution: {integrity: sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==}
+  '@aws-sdk/eventstream-handler-node@3.972.34':
+    resolution: {integrity: sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-eventstream@3.972.10':
-    resolution: {integrity: sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==}
+  '@aws-sdk/middleware-eventstream@3.972.29':
+    resolution: {integrity: sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-host-header@3.972.10':
-    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-logger@3.972.10':
-    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-recursion-detection@3.972.11':
-    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-sdk-s3@3.972.37':
-    resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-user-agent@3.972.38':
-    resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-websocket@3.972.16':
-    resolution: {integrity: sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==}
+  '@aws-sdk/middleware-websocket@3.972.52':
+    resolution: {integrity: sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.6':
-    resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.972.13':
-    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/signature-v4-multi-region@3.996.25':
-    resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1041.0':
-    resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1044.0':
-    resolution: {integrity: sha512-uvpWTfpzOM9qVrR0kdAjzBbvv2ERW7S1CKeBeRkHyHy21Ext5fNReIVrbAzhjuVC7UxRyZQ8PHYW/3T83hWlbg==}
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.8':
     resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-arn-parser@3.972.3':
-    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-endpoints@3.996.8':
-    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-format-url@3.972.10':
-    resolution: {integrity: sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==}
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.5':
     resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-user-agent-browser@3.972.10':
-    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
-
-  '@aws-sdk/util-user-agent-node@3.973.24':
-    resolution: {integrity: sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
-
-  '@aws-sdk/xml-builder@3.972.22':
-    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws/lambda-invoke-store@0.2.4':
-    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
-  '@borewit/text-codec@0.2.2':
-    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+  '@earendil-works/pi-agent-core@0.84.3':
+    resolution: {integrity: sha512-VURr+xBRl3RxYcw3kT9Pn3yfi6LbRoCJgHF7h1mAblMjtLNV/MfG/RyF0uJizBAM886AEakSiw3j9c/aSngppg==}
+    engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-agent-core@0.74.0':
-    resolution: {integrity: sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@earendil-works/pi-ai@0.74.0':
-    resolution: {integrity: sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==}
-    engines: {node: '>=20.0.0'}
+  '@earendil-works/pi-ai@0.84.3':
+    resolution: {integrity: sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ==}
+    engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-coding-agent@0.74.0':
-    resolution: {integrity: sha512-Q5GikbB5vRBrsrrf/uvet53rPSQ1sn5I5mO+l7sIobdXYpS04/X2oOc2UHFm90fNdkl3yU+ANTZL0zOtHbnqRw==}
-    engines: {node: '>=20.6.0'}
+  '@earendil-works/pi-client@0.84.3':
+    resolution: {integrity: sha512-zfErYane+390W0xpBJ/FWCp6aktPpkpcIcXUeZiAziWLoxE80ZNQALRyOSa/gGS5V+1OkNnMYxRxbzN0zUvnOA==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-coding-agent@0.84.3':
+    resolution: {integrity: sha512-Yr2p9PubrbFZmYEPYI+C8KmZP9xlFuLDnAG64RtU0ZDgrdiXYWa+y7WGyJO5OlqPliOkVCMd9IzVszO3/t0D0w==}
+    engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-tui@0.74.0':
-    resolution: {integrity: sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==}
-    engines: {node: '>=20.0.0'}
+  '@earendil-works/pi-protocol@0.84.3':
+    resolution: {integrity: sha512-9a4g6WhLOvRqvsIOFaWxg/2gdrbY4Thclwj5ipLUPAWChfsDJ/8XdPc2sRhSOkD6EsxpEFJz3xppcfwI6EcZDg==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-telemetry@0.84.3':
+    resolution: {integrity: sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-tui@0.84.3':
+    resolution: {integrity: sha512-fS6OEQKEEALnKa6Uw8LcgZZ+9CWck7f3MQSCETQp6leUgIFwMEDtKmOUnL9nsYm+RIPmy7OmplVxYRbV6hiaFg==}
+    engines: {node: '>=22.19.0'}
 
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
@@ -218,79 +179,73 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.2':
-    resolution: {integrity: sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==}
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-universal@0.3.2':
-    resolution: {integrity: sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==}
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
     engines: {node: '>= 10'}
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-x64@0.3.2':
-    resolution: {integrity: sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==}
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    resolution: {integrity: sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
-    resolution: {integrity: sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==}
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
-    resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
-    resolution: {integrity: sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==}
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
-    resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
-    resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
-    resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
-    resolution: {integrity: sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==}
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    resolution: {integrity: sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@mariozechner/clipboard@0.3.5':
-    resolution: {integrity: sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==}
+  '@mariozechner/clipboard@0.3.9':
+    resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
     engines: {node: '>= 10'}
-
-  '@mistralai/mistralai@2.2.1':
-    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
-
-  '@nodable/entities@2.1.0':
-    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -325,209 +280,49 @@ packages:
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
 
-  '@smithy/config-resolver@4.4.17':
-    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/core@3.23.17':
-    resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/credential-provider-imds@4.2.14':
-    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-codec@4.2.14':
-    resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-browser@4.2.14':
-    resolution: {integrity: sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-config-resolver@4.3.14':
-    resolution: {integrity: sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-node@4.2.14':
-    resolution: {integrity: sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-universal@4.2.14':
-    resolution: {integrity: sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/fetch-http-handler@5.3.17':
-    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/hash-node@4.2.14':
-    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/invalid-dependency@4.2.14':
-    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/is-array-buffer@4.2.2':
-    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+  '@smithy/node-http-handler@4.11.3':
+    resolution: {integrity: sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-content-length@4.2.14':
-    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@4.4.32':
-    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-retry@4.5.7':
-    resolution: {integrity: sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-serde@4.2.20':
-    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-stack@4.2.14':
-    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-config-provider@4.3.14':
-    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-http-handler@4.6.1':
-    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/property-provider@4.2.14':
-    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/protocol-http@5.3.14':
-    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-builder@4.2.14':
-    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-parser@4.2.14':
-    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/service-error-classification@4.3.1':
-    resolution: {integrity: sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/shared-ini-file-loader@4.4.9':
-    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/signature-v4@5.3.14':
-    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/smithy-client@4.12.13':
-    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.14.1':
     resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/url-parser@4.2.14':
-    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-base64@4.3.2':
-    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-browser@4.2.2':
-    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-node@4.2.3':
-    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
     resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-buffer-from@4.2.2':
-    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-config-provider@4.2.2':
-    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-browser@4.3.49':
-    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-node@4.2.54':
-    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-endpoints@3.4.2':
-    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-hex-encoding@4.2.2':
-    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-middleware@4.2.14':
-    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-retry@4.3.8':
-    resolution: {integrity: sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-stream@4.5.25':
-    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-uri-escape@4.2.2':
-    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
-
-  '@smithy/util-utf8@4.2.2':
-    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/uuid@1.1.2':
-    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
-    engines: {node: '>=18.0.0'}
-
-  '@tokenizer/inflate@0.4.1':
-    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
-    engines: {node: '>=18'}
-
-  '@tokenizer/token@0.3.0':
-    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
-
-  '@tootallnate/quickjs-emscripten@0.23.0':
-    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
-
-  '@types/mime-types@2.1.4':
-    resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
-
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@types/node@25.6.1':
     resolution: {integrity: sha512-coJCN8O1q4AGyyqCAUSP06P+SrMTu18BkEj3NVAK07q6QUneD2wzj3CLv9+yP+BMeZQlMvneXqqvDe3w+xcq7g==}
@@ -535,31 +330,9 @@ packages:
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-
-  any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
-
-  ast-types@0.13.4:
-    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
-    engines: {node: '>=4'}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -567,10 +340,6 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  basic-ftp@5.3.1:
-    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
-    engines: {node: '>=10.0.0'}
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
@@ -582,42 +351,20 @@ packages:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-
-  chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  cli-highlight@2.1.11:
-    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
-    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
-    hasBin: true
-
-  cliui@7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
-
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
-
-  data-uri-to-buffer@6.0.2:
-    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
-    engines: {node: '>= 14'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -628,10 +375,6 @@ packages:
       supports-color:
         optional: true
 
-  degenerator@5.0.1:
-    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
-    engines: {node: '>= 14'}
-
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -639,59 +382,12 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
-  escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
-
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
-
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
-
-  esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
-
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
-  fast-xml-builder@1.1.9:
-    resolution: {integrity: sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==}
-
-  fast-xml-parser@5.7.2:
-    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
-    hasBin: true
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
-
-  file-type@21.3.4:
-    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
-    engines: {node: '>=20'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -705,25 +401,9 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
-  get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-
-  get-east-asian-width@1.5.0:
-    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
-
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
-  get-uri@6.0.5:
-    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
-    engines: {node: '>= 14'}
-
-  glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
 
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
@@ -735,6 +415,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  grok-mermaid@0.2.2:
+    resolution: {integrity: sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==}
+    engines: {node: '>=18'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -755,20 +439,12 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
-    engines: {node: '>= 12'}
-
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -787,9 +463,6 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
-  koffi@2.16.1:
-    resolution: {integrity: sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -797,40 +470,17 @@ packages:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
 
-  lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
-
-  marked@15.0.12:
-    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
-    engines: {node: '>= 18'}
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
     hasBin: true
-
-  mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
-
-  netmask@2.1.1:
-    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
-    engines: {node: '>= 0.4.0'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -841,16 +491,8 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
-  openai@6.26.0:
-    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
-    hasBin: true
+  openai@6.40.0:
+    resolution: {integrity: sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==}
     peerDependencies:
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
@@ -864,36 +506,12 @@ packages:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
 
-  pac-proxy-agent@7.2.0:
-    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
-    engines: {node: '>= 14'}
-
-  pac-resolver@7.0.1:
-    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
-    engines: {node: '>= 14'}
-
-  parse5-htmlparser2-tree-adapter@6.0.1:
-    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
-
-  parse5@5.1.1:
-    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
-
-  parse5@6.0.1:
-    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
-
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
-  path-expression-matcher@1.5.0:
-    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
-    engines: {node: '>=14.0.0'}
-
-  path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
-
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
@@ -901,20 +519,6 @@ packages:
   protobufjs@7.5.6:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
-
-  proxy-agent@6.5.0:
-    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
-    engines: {node: '>= 14'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
@@ -927,58 +531,25 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-
-  smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
-
-  socks@2.8.8:
-    resolution: {integrity: sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
-
-  strnum@2.2.3:
-    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
-
-  strtok3@10.3.5:
-    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
-    engines: {node: '>=18'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-
-  thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
-
-  thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
-
-  token-types@6.1.2:
-    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
-    engines: {node: '>=14.16'}
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -986,39 +557,29 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typebox@1.1.38:
-    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+  typebox@1.3.7:
+    resolution: {integrity: sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  uint8array-extras@1.5.0:
-    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
-    engines: {node: '>=18'}
-
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
-    engines: {node: '>=20.18.1'}
-
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
-    hasBin: true
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
@@ -1032,30 +593,10 @@ packages:
       utf-8-validate:
         optional: true
 
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
-  yaml@2.8.4:
-    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
-
-  yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
-
-  yargs@16.2.0:
-    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
-    engines: {node: '>=10'}
-
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
-
-  zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
-    peerDependencies:
-      zod: ^3.25.28 || ^4
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -1067,12 +608,6 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
-
-  '@aws-crypto/crc32@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
-      tslib: 2.8.1
 
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
@@ -1100,481 +635,287 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-bedrock-runtime@3.1044.0':
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/credential-provider-node': 3.972.39
-      '@aws-sdk/eventstream-handler-node': 3.972.14
-      '@aws-sdk/middleware-eventstream': 3.972.10
-      '@aws-sdk/middleware-host-header': 3.972.10
-      '@aws-sdk/middleware-logger': 3.972.10
-      '@aws-sdk/middleware-recursion-detection': 3.972.11
-      '@aws-sdk/middleware-user-agent': 3.972.38
-      '@aws-sdk/middleware-websocket': 3.972.16
-      '@aws-sdk/region-config-resolver': 3.972.13
-      '@aws-sdk/token-providers': 3.1044.0
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/eventstream-handler-node': 3.972.34
+      '@aws-sdk/middleware-eventstream': 3.972.29
+      '@aws-sdk/middleware-websocket': 3.972.52
+      '@aws-sdk/token-providers': 3.1048.0
       '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.8
-      '@aws-sdk/util-user-agent-browser': 3.972.10
-      '@aws-sdk/util-user-agent-node': 3.973.24
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/core': 3.23.17
-      '@smithy/eventstream-serde-browser': 4.2.14
-      '@smithy/eventstream-serde-config-resolver': 4.3.14
-      '@smithy/eventstream-serde-node': 4.2.14
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/hash-node': 4.2.14
-      '@smithy/invalid-dependency': 4.2.14
-      '@smithy/middleware-content-length': 4.2.14
-      '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/middleware-retry': 4.5.7
-      '@smithy/middleware-serde': 4.2.20
-      '@smithy/middleware-stack': 4.2.14
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.49
-      '@smithy/util-defaults-mode-node': 4.2.54
-      '@smithy/util-endpoints': 3.4.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.8
-      '@smithy/util-stream': 4.5.25
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/core@3.974.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/xml-builder': 3.972.22
-      '@smithy/core': 3.23.17
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.8
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.972.34':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.7.3
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.36':
+  '@aws-sdk/core@3.977.9':
     dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/property-provider': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/util-stream': 4.5.25
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.38':
+  '@aws-sdk/credential-provider-env@3.972.70':
     dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/credential-provider-env': 3.972.34
-      '@aws-sdk/credential-provider-http': 3.972.36
-      '@aws-sdk/credential-provider-login': 3.972.38
-      '@aws-sdk/credential-provider-process': 3.972.34
-      '@aws-sdk/credential-provider-sso': 3.972.38
-      '@aws-sdk/credential-provider-web-identity': 3.972.38
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/credential-provider-imds': 4.2.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-login@3.972.38':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.972.39':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.34
-      '@aws-sdk/credential-provider-http': 3.972.36
-      '@aws-sdk/credential-provider-ini': 3.972.38
-      '@aws-sdk/credential-provider-process': 3.972.34
-      '@aws-sdk/credential-provider-sso': 3.972.38
-      '@aws-sdk/credential-provider-web-identity': 3.972.38
-      '@aws-sdk/types': 3.973.8
-      '@smithy/credential-provider-imds': 4.2.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-process@3.972.34':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.972.38':
+  '@aws-sdk/credential-provider-http@3.972.72':
     dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/token-providers': 3.1041.0
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-web-identity@3.972.38':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/eventstream-handler-node@3.972.14':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/eventstream-codec': 4.2.14
-      '@smithy/types': 4.14.1
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-eventstream@3.972.10':
+  '@aws-sdk/credential-provider-ini@3.973.15':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-host-header@3.972.10':
+  '@aws-sdk/credential-provider-login@3.972.77':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-logger@3.972.10':
+  '@aws-sdk/credential-provider-node@3.972.81':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-recursion-detection@3.972.11':
+  '@aws-sdk/credential-provider-process@3.972.70':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.972.37':
+  '@aws-sdk/credential-provider-sso@3.973.14':
     dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-arn-parser': 3.972.3
-      '@smithy/core': 3.23.17
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-stream': 4.5.25
-      '@smithy/util-utf8': 4.2.2
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.38':
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
     dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.8
-      '@smithy/core': 3.23.17
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-retry': 4.3.8
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-websocket@3.972.16':
+  '@aws-sdk/eventstream-handler-node@3.972.34':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-format-url': 3.972.10
-      '@smithy/eventstream-codec': 4.2.14
-      '@smithy/eventstream-serde-browser': 4.2.14
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.997.6':
+  '@aws-sdk/middleware-eventstream@3.972.29':
     dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/middleware-host-header': 3.972.10
-      '@aws-sdk/middleware-logger': 3.972.10
-      '@aws-sdk/middleware-recursion-detection': 3.972.11
-      '@aws-sdk/middleware-user-agent': 3.972.38
-      '@aws-sdk/region-config-resolver': 3.972.13
-      '@aws-sdk/signature-v4-multi-region': 3.996.25
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.8
-      '@aws-sdk/util-user-agent-browser': 3.972.10
-      '@aws-sdk/util-user-agent-node': 3.973.24
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/core': 3.23.17
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/hash-node': 4.2.14
-      '@smithy/invalid-dependency': 4.2.14
-      '@smithy/middleware-content-length': 4.2.14
-      '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/middleware-retry': 4.5.7
-      '@smithy/middleware-serde': 4.2.20
-      '@smithy/middleware-stack': 4.2.14
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.49
-      '@smithy/util-defaults-mode-node': 4.2.54
-      '@smithy/util-endpoints': 3.4.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.8
-      '@smithy/util-utf8': 4.2.2
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
-  '@aws-sdk/region-config-resolver@3.972.13':
+  '@aws-sdk/middleware-websocket@3.972.52':
     dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.44':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
       '@aws-sdk/types': 3.973.8
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/node-config-provider': 4.3.14
+      '@smithy/core': 3.33.3
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.996.25':
+  '@aws-sdk/token-providers@3.1116.0':
     dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.37
-      '@aws-sdk/types': 3.973.8
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/types': 4.14.1
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1041.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/token-providers@3.1044.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/types@3.973.8':
     dependencies:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-arn-parser@3.972.3':
+  '@aws-sdk/types@3.974.5':
     dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-endpoints@3.996.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-endpoints': 3.4.2
-      tslib: 2.8.1
-
-  '@aws-sdk/util-format-url@3.972.10':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/querystring-builder': 4.2.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.5':
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-browser@3.972.10':
+  '@aws-sdk/xml-builder@3.972.40':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
-      bowser: 2.14.1
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.973.24':
-    dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.38
-      '@aws-sdk/types': 3.973.8
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-config-provider': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.22':
-    dependencies:
-      '@nodable/entities': 2.1.0
-      '@smithy/types': 4.14.1
-      fast-xml-parser: 5.7.2
-      tslib: 2.8.1
-
-  '@aws/lambda-invoke-store@0.2.4': {}
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/runtime@7.29.2': {}
 
-  '@borewit/text-codec@0.2.2': {}
-
-  '@earendil-works/pi-agent-core@0.74.0(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.84.3(supports-color@7.2.0)(ws@8.20.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.74.0(ws@8.20.0)(zod@4.4.3)
-      typebox: 1.1.38
+      '@earendil-works/pi-ai': 0.84.3(supports-color@7.2.0)(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-telemetry': 0.84.3
+      diff: 8.0.4
+      ignore: 7.0.5
+      typebox: 1.3.7
+      yaml: 2.9.0
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
-      - aws-crt
       - bufferutil
       - supports-color
       - utf-8-validate
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.74.0(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.84.3(supports-color@7.2.0)(ws@8.20.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
-      '@aws-sdk/client-bedrock-runtime': 3.1044.0
-      '@google/genai': 1.52.0
-      '@mistralai/mistralai': 2.2.1
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@earendil-works/pi-telemetry': 0.84.3
+      '@google/genai': 1.52.0(supports-color@7.2.0)
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      openai: 6.40.0(ws@8.20.0)(zod@4.4.3)
       partial-json: 0.1.7
-      proxy-agent: 6.5.0
-      typebox: 1.1.38
-      undici: 7.25.0
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
+      typebox: 1.3.7
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
-      - aws-crt
       - bufferutil
       - supports-color
       - utf-8-validate
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.74.0(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-client@0.84.3':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.74.0(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.74.0(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.74.0
+      '@earendil-works/pi-protocol': 0.84.3
+
+  '@earendil-works/pi-coding-agent@0.84.3(supports-color@7.2.0)(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.84.3(supports-color@7.2.0)(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.3(supports-color@7.2.0)(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-client': 0.84.3
+      '@earendil-works/pi-protocol': 0.84.3
+      '@earendil-works/pi-tui': 0.84.3
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
-      cli-highlight: 2.1.11
+      cross-spawn: 7.0.6
       diff: 8.0.4
-      extract-zip: 2.0.1
-      file-type: 21.3.4
-      glob: 13.0.6
+      grok-mermaid: 0.2.2
+      highlight.js: 10.7.3
       hosted-git-info: 9.0.3
       ignore: 7.0.5
       jiti: 2.7.0
-      marked: 15.0.12
       minimatch: 10.2.5
       proper-lockfile: 4.1.2
-      strip-ansi: 7.2.0
-      typebox: 1.1.38
-      undici: 7.25.0
-      uuid: 14.0.0
-      yaml: 2.8.4
+      semver: 7.8.0
+      typebox: 1.3.7
+      undici: 8.9.0
+      yaml: 2.9.0
     optionalDependencies:
-      '@mariozechner/clipboard': 0.3.5
+      '@mariozechner/clipboard': 0.3.9
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
-      - aws-crt
       - bufferutil
       - supports-color
       - utf-8-validate
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.74.0':
+  '@earendil-works/pi-protocol@0.84.3':
     dependencies:
-      '@types/mime-types': 2.1.4
-      chalk: 5.6.2
-      get-east-asian-width: 1.5.0
-      marked: 15.0.12
-      mime-types: 3.0.2
-    optionalDependencies:
-      koffi: 2.16.1
+      typebox: 1.3.7
 
-  '@google/genai@1.52.0':
+  '@earendil-works/pi-telemetry@0.84.3': {}
+
+  '@earendil-works/pi-tui@0.84.3':
     dependencies:
-      google-auth-library: 10.6.2
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
+
+  '@google/genai@1.52.0(supports-color@7.2.0)':
+    dependencies:
+      google-auth-library: 10.6.2(supports-color@7.2.0)
       p-retry: 4.6.2
       protobufjs: 7.5.6
       ws: 8.20.0
@@ -1583,60 +924,49 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.2':
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-darwin-universal@0.3.2':
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-darwin-x64@0.3.2':
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard@0.3.5':
+  '@mariozechner/clipboard@0.3.9':
     optionalDependencies:
-      '@mariozechner/clipboard-darwin-arm64': 0.3.2
-      '@mariozechner/clipboard-darwin-universal': 0.3.2
-      '@mariozechner/clipboard-darwin-x64': 0.3.2
-      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.2
-      '@mariozechner/clipboard-linux-arm64-musl': 0.3.2
-      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.2
-      '@mariozechner/clipboard-linux-x64-gnu': 0.3.2
-      '@mariozechner/clipboard-linux-x64-musl': 0.3.2
-      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.2
-      '@mariozechner/clipboard-win32-x64-msvc': 0.3.2
+      '@mariozechner/clipboard-darwin-arm64': 0.3.9
+      '@mariozechner/clipboard-darwin-universal': 0.3.9
+      '@mariozechner/clipboard-darwin-x64': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.9
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.9
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.9
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
     optional: true
-
-  '@mistralai/mistralai@2.2.1':
-    dependencies:
-      ws: 8.20.0
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@nodable/entities@2.1.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -1663,222 +993,50 @@ snapshots:
 
   '@silvia-odwyer/photon-node@0.3.4': {}
 
-  '@smithy/config-resolver@4.4.17':
+  '@smithy/core@3.33.3':
     dependencies:
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.4.2
-      '@smithy/util-middleware': 4.2.14
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@smithy/core@3.23.17':
+  '@smithy/credential-provider-imds@4.5.2':
     dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-stream': 4.5.25
-      '@smithy/util-utf8': 4.2.2
-      '@smithy/uuid': 1.1.2
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@smithy/credential-provider-imds@4.2.14':
+  '@smithy/fetch-http-handler@5.7.2':
     dependencies:
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      tslib: 2.8.1
-
-  '@smithy/eventstream-codec@4.2.14':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.1
-      '@smithy/util-hex-encoding': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-browser@4.2.14':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-config-resolver@4.3.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-node@4.2.14':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-universal@4.2.14':
-    dependencies:
-      '@smithy/eventstream-codec': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/fetch-http-handler@5.3.17':
-    dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/querystring-builder': 4.2.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-base64': 4.3.2
-      tslib: 2.8.1
-
-  '@smithy/hash-node@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/invalid-dependency@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/is-array-buffer@4.2.2':
+  '@smithy/node-http-handler@4.11.3':
     dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@smithy/middleware-content-length@4.2.14':
+  '@smithy/node-http-handler@4.7.3':
     dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@smithy/middleware-endpoint@4.4.32':
+  '@smithy/signature-v4@5.7.3':
     dependencies:
-      '@smithy/core': 3.23.17
-      '@smithy/middleware-serde': 4.2.20
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-middleware': 4.2.14
-      tslib: 2.8.1
-
-  '@smithy/middleware-retry@4.5.7':
-    dependencies:
-      '@smithy/core': 3.23.17
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/service-error-classification': 4.3.1
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.8
-      '@smithy/uuid': 1.1.2
-      tslib: 2.8.1
-
-  '@smithy/middleware-serde@4.2.20':
-    dependencies:
-      '@smithy/core': 3.23.17
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/middleware-stack@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/node-config-provider@4.3.14':
-    dependencies:
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/node-http-handler@4.6.1':
-    dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/querystring-builder': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/property-provider@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/protocol-http@5.3.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/querystring-builder@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      '@smithy/util-uri-escape': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/querystring-parser@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/service-error-classification@4.3.1':
-    dependencies:
-      '@smithy/types': 4.14.1
-
-  '@smithy/shared-ini-file-loader@4.4.9':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/signature-v4@5.3.14':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.2
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-uri-escape': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/smithy-client@4.12.13':
-    dependencies:
-      '@smithy/core': 3.23.17
-      '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/middleware-stack': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-stream': 4.5.25
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/types@4.14.1':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/url-parser@4.2.14':
-    dependencies:
-      '@smithy/querystring-parser': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/util-base64@4.3.2':
-    dependencies:
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-browser@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-node@4.2.3':
+  '@smithy/types@4.17.2':
     dependencies:
       tslib: 2.8.1
 
@@ -1887,98 +1045,10 @@ snapshots:
       '@smithy/is-array-buffer': 2.2.0
       tslib: 2.8.1
 
-  '@smithy/util-buffer-from@4.2.2':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-config-provider@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-browser@4.3.49':
-    dependencies:
-      '@smithy/property-provider': 4.2.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-node@4.2.54':
-    dependencies:
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/credential-provider-imds': 4.2.14
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/util-endpoints@3.4.2':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/util-hex-encoding@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-middleware@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/util-retry@4.3.8':
-    dependencies:
-      '@smithy/service-error-classification': 4.3.1
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.5.25':
-    dependencies:
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/types': 4.14.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-uri-escape@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
   '@smithy/util-utf8@2.3.0':
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
-
-  '@smithy/util-utf8@4.2.2':
-    dependencies:
-      '@smithy/util-buffer-from': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/uuid@1.1.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@tokenizer/inflate@0.4.1':
-    dependencies:
-      debug: 4.4.3
-      token-types: 6.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@tokenizer/token@0.3.0': {}
-
-  '@tootallnate/quickjs-emscripten@0.23.0': {}
-
-  '@types/mime-types@2.1.4': {}
-
-  '@types/node@25.6.0':
-    dependencies:
-      undici-types: 7.19.2
 
   '@types/node@25.6.1':
     dependencies:
@@ -1986,32 +1056,11 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 25.6.0
-    optional: true
-
   agent-base@7.1.4: {}
-
-  ansi-regex@5.0.1: {}
-
-  ansi-regex@6.2.2: {}
-
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
-
-  any-promise@1.3.0: {}
-
-  ast-types@0.13.4:
-    dependencies:
-      tslib: 2.8.1
 
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
-
-  basic-ftp@5.3.1: {}
 
   bignumber.js@9.3.1: {}
 
@@ -2021,51 +1070,23 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  buffer-crc32@0.2.13: {}
-
   buffer-equal-constant-time@1.0.1: {}
-
-  chalk@4.1.2:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
 
   chalk@5.6.2: {}
 
-  cli-highlight@2.1.11:
+  cross-spawn@7.0.6:
     dependencies:
-      chalk: 4.1.2
-      highlight.js: 10.7.3
-      mz: 2.7.0
-      parse5: 5.1.1
-      parse5-htmlparser2-tree-adapter: 6.0.1
-      yargs: 16.2.0
-
-  cliui@7.0.4:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   data-uri-to-buffer@4.0.1: {}
 
-  data-uri-to-buffer@6.0.2: {}
-
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
-
-  degenerator@5.0.1:
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 2.1.0
-      esprima: 4.0.1
+    optionalDependencies:
+      supports-color: 7.2.0
 
   diff@8.0.4: {}
 
@@ -2073,117 +1094,41 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  emoji-regex@8.0.0: {}
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
-
-  escalade@3.2.0: {}
-
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
-
-  esprima@4.0.1: {}
-
-  estraverse@5.3.0: {}
-
-  esutils@2.0.3: {}
-
   extend@3.0.2: {}
-
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
-  fast-xml-builder@1.1.9:
-    dependencies:
-      path-expression-matcher: 1.5.0
-
-  fast-xml-parser@5.7.2:
-    dependencies:
-      '@nodable/entities': 2.1.0
-      fast-xml-builder: 1.1.9
-      path-expression-matcher: 1.5.0
-      strnum: 2.2.3
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  file-type@21.3.4:
-    dependencies:
-      '@tokenizer/inflate': 0.4.1
-      strtok3: 10.3.5
-      token-types: 6.1.2
-      uint8array-extras: 1.5.0
-    transitivePeerDependencies:
-      - supports-color
-
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
 
-  gaxios@7.1.4:
+  gaxios@7.1.4(supports-color@7.2.0):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
       node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
 
-  gcp-metadata@8.1.2:
+  gcp-metadata@8.1.2(supports-color@7.2.0):
     dependencies:
-      gaxios: 7.1.4
+      gaxios: 7.1.4(supports-color@7.2.0)
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
-  get-caller-file@2.0.5: {}
+  get-east-asian-width@1.6.0: {}
 
-  get-east-asian-width@1.5.0: {}
-
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.4
-
-  get-uri@6.0.5:
-    dependencies:
-      basic-ftp: 5.3.1
-      data-uri-to-buffer: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  glob@13.0.6:
-    dependencies:
-      minimatch: 10.2.5
-      minipass: 7.1.3
-      path-scurry: 2.0.2
-
-  google-auth-library@10.6.2:
+  google-auth-library@10.6.2(supports-color@7.2.0):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.4
-      gcp-metadata: 8.1.2
+      gaxios: 7.1.4(supports-color@7.2.0)
+      gcp-metadata: 8.1.2(supports-color@7.2.0)
       google-logging-utils: 1.1.3
       jws: 4.0.1
     transitivePeerDependencies:
@@ -2193,7 +1138,10 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  has-flag@4.0.0: {}
+  grok-mermaid@0.2.2: {}
+
+  has-flag@4.0.0:
+    optional: true
 
   highlight.js@10.7.3: {}
 
@@ -2201,27 +1149,23 @@ snapshots:
     dependencies:
       lru-cache: 11.3.6
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
-
-  ieee754@1.2.1: {}
 
   ignore@7.0.5: {}
 
-  ip-address@10.2.0: {}
-
-  is-fullwidth-code-point@3.0.0: {}
+  isexe@2.0.0: {}
 
   jiti@2.7.0: {}
 
@@ -2245,38 +1189,17 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
-  koffi@2.16.1:
-    optional: true
-
   long@5.3.2: {}
 
   lru-cache@11.3.6: {}
 
-  lru-cache@7.18.3: {}
-
-  marked@15.0.12: {}
-
-  mime-db@1.54.0: {}
-
-  mime-types@3.0.2:
-    dependencies:
-      mime-db: 1.54.0
+  marked@18.0.5: {}
 
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
 
-  minipass@7.1.3: {}
-
   ms@2.1.3: {}
-
-  mz@2.7.0:
-    dependencies:
-      any-promise: 1.3.0
-      object-assign: 4.1.1
-      thenify-all: 1.6.0
-
-  netmask@2.1.1: {}
 
   node-domexception@1.0.0: {}
 
@@ -2286,13 +1209,7 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  object-assign@4.1.1: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
-
-  openai@6.26.0(ws@8.20.0)(zod@4.4.3):
+  openai@6.40.0(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.20.0
       zod: 4.4.3
@@ -2302,42 +1219,9 @@ snapshots:
       '@types/retry': 0.12.0
       retry: 0.13.1
 
-  pac-proxy-agent@7.2.0:
-    dependencies:
-      '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.4
-      debug: 4.4.3
-      get-uri: 6.0.5
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  pac-resolver@7.0.1:
-    dependencies:
-      degenerator: 5.0.1
-      netmask: 2.1.1
-
-  parse5-htmlparser2-tree-adapter@6.0.1:
-    dependencies:
-      parse5: 6.0.1
-
-  parse5@5.1.1: {}
-
-  parse5@6.0.1: {}
-
   partial-json@0.1.7: {}
 
-  path-expression-matcher@1.5.0: {}
-
-  path-scurry@2.0.2:
-    dependencies:
-      lru-cache: 11.3.6
-      minipass: 7.1.3
-
-  pend@1.2.0: {}
+  path-key@3.1.1: {}
 
   proper-lockfile@4.1.2:
     dependencies:
@@ -2357,30 +1241,8 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 25.6.0
+      '@types/node': 25.6.1
       long: 5.3.2
-
-  proxy-agent@6.5.0:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  proxy-from-env@1.1.0: {}
-
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
-  require-directory@2.1.1: {}
 
   retry@0.12.0: {}
 
@@ -2388,115 +1250,42 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  semver@7.8.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   signal-exit@3.0.7: {}
-
-  smart-buffer@4.2.0: {}
-
-  socks-proxy-agent@8.0.5:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-      socks: 2.8.8
-    transitivePeerDependencies:
-      - supports-color
-
-  socks@2.8.8:
-    dependencies:
-      ip-address: 10.2.0
-      smart-buffer: 4.2.0
-
-  source-map@0.6.1:
-    optional: true
-
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
-
-  strnum@2.2.3: {}
-
-  strtok3@10.3.5:
-    dependencies:
-      '@tokenizer/token': 0.3.0
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-
-  thenify-all@1.6.0:
-    dependencies:
-      thenify: 3.3.1
-
-  thenify@3.3.1:
-    dependencies:
-      any-promise: 1.3.0
-
-  token-types@6.1.2:
-    dependencies:
-      '@borewit/text-codec': 0.2.2
-      '@tokenizer/token': 0.3.0
-      ieee754: 1.2.1
+    optional: true
 
   ts-algebra@2.0.0: {}
 
   tslib@2.8.1: {}
 
-  typebox@1.1.38: {}
+  typebox@1.3.7: {}
 
   typescript@6.0.3: {}
 
-  uint8array-extras@1.5.0: {}
-
   undici-types@7.19.2: {}
 
-  undici@7.25.0: {}
-
-  uuid@14.0.0: {}
+  undici@8.9.0: {}
 
   web-streams-polyfill@3.3.3: {}
 
-  wrap-ansi@7.0.0:
+  which@2.0.2:
     dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  wrappy@1.0.2: {}
+      isexe: 2.0.0
 
   ws@8.20.0: {}
 
-  y18n@5.0.8: {}
+  yaml@2.9.0: {}
 
-  yaml@2.8.4: {}
-
-  yargs-parser@20.2.9: {}
-
-  yargs@16.2.0:
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 20.2.9
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
-
-  zod-to-json-schema@3.25.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
-
-  zod@4.4.3: {}
+  zod@4.4.3:
+    optional: true

--- a/tests/blocks.test.ts
+++ b/tests/blocks.test.ts
@@ -92,6 +92,41 @@ test("parseHistoryArtifacts accepts the current v4 structured JSON artifact cont
 	});
 });
 
+test("parseHistoryArtifacts accepts one JSON Markdown fence around a valid artifact", () => {
+	const wrapped = [
+		"Here is the requested handoff:",
+		"```JSON",
+		validArtifacts,
+		"```",
+		"",
+		"No other content belongs to the artifact.",
+	].join("\n");
+
+	assert.equal(parseOk(wrapped).briefMarkdown, parseOk(validArtifacts).briefMarkdown);
+});
+
+test("parseHistoryArtifacts reads a valid artifact through model presentation wrappers", () => {
+	const fenced = (language: string) => ["```" + language, validArtifacts, "```"].join("\n");
+	const expected = parseOk(validArtifacts).briefMarkdown;
+	assert.equal(parseOk(fenced("typescript")).briefMarkdown, expected);
+	assert.equal(parseOk([fenced("typescript"), fenced("json")].join("\n")).briefMarkdown, expected);
+	assert.equal(parseOk(`<think>\nThe contract wants one JSON object.\n</think>\n\n${validArtifacts}`).briefMarkdown, expected);
+	assert.equal(parseOk(`Here is the handoff:\n\n${validArtifacts}\n\nTell me if anything else is needed.`).briefMarkdown, expected);
+});
+
+test("parseHistoryArtifacts still fails closed on unusable model output", () => {
+	parseFail("I was unable to summarize this session.", "artifact-invalid-json");
+	parseFail(validArtifacts.slice(0, Math.floor(validArtifacts.length / 2)), "artifact-invalid-json");
+	parseFail(`Here is the handoff:\n\n${JSON.stringify(envelope({ brief: { task: "only a task" } }))}`);
+});
+
+test("parseHistoryArtifacts fails closed when a response carries competing artifacts", () => {
+	const other = JSON.stringify(envelope({
+		brief: briefEnvelope({ task: "A different task than the final artifact claims." }),
+	}));
+	parseFail(["```json", validArtifacts, "```", "", "```json", other, "```"].join("\n"), "artifact-ambiguous");
+});
+
 test("parseHistoryArtifacts renders only populated brief sections", () => {
 	const parsed = parseOk(JSON.stringify(envelope({
 		brief: briefEnvelope({ forbid: [], established: [], learned: [], open: [], next: [] }),
@@ -110,25 +145,36 @@ test("parseHistoryArtifacts accepts a full agent guide replacement", () => {
 	assert.equal(parsed.agentGuideChangeReason, "capture corrected command truth");
 });
 
-test("parseHistoryArtifacts rejects wrong top-level keys", () => {
-	parseFail(JSON.stringify({
+test("parseHistoryArtifacts ignores unknown envelope, brief, and entry keys", () => {
+	const expected = parseOk(validArtifacts).briefMarkdown;
+	assert.equal(parseOk(JSON.stringify({
 		version: "pi-continue-artifacts/v4",
-		brief: briefEnvelope(),
-		agentGuideUpdate: { content: null, reason: "ok" },
-		extra: "noise",
-	}));
+		brief: { ...briefEnvelope(), commentary: ["noise"] },
+		agentGuideUpdate: { content: null, reason: "no durable guide change this cycle", confidence: 0.4 },
+		notes: "noise",
+	})).briefMarkdown, expected);
+	assert.equal(parseOk(JSON.stringify(envelope({
+		brief: briefEnvelope({
+			learned: [{
+				lesson: "Embedded newlines inside a field should render as one bullet entry.",
+				source: "parser normalization fixture",
+				confidence: "high",
+			}],
+		}),
+	}))).briefMarkdown, expected);
 });
 
-test("parseHistoryArtifacts rejects wrong brief keys", () => {
-	parseFail(JSON.stringify(envelope({
-		brief: { ...briefEnvelope(), extraSlot: ["nope"] },
-	})));
-});
+test("parseHistoryArtifacts requires the version and every brief slot", () => {
+	const versionless = envelope();
+	delete (versionless as Record<string, unknown>).version;
+	parseFail(JSON.stringify(versionless));
 
-test("parseHistoryArtifacts rejects a brief missing the learned slot", () => {
-	const noLearned = briefEnvelope();
-	delete (noLearned as Record<string, unknown>).learned;
-	parseFail(JSON.stringify(envelope({ brief: noLearned })));
+	for (const slot of ["forbid", "established", "learned", "open", "next"]) {
+		const partialBrief = briefEnvelope();
+		delete (partialBrief as Record<string, unknown>)[slot];
+		parseFail(JSON.stringify(envelope({ brief: partialBrief })));
+		parseFail(JSON.stringify(envelope({ brief: briefEnvelope({ [slot]: null }) })));
+	}
 });
 
 test("parseHistoryArtifacts rejects empty task or done_when", () => {
@@ -184,12 +230,6 @@ test("parseHistoryArtifacts rejects learned entries missing fields", () => {
 	})));
 });
 
-test("parseHistoryArtifacts rejects learned entries with extra keys", () => {
-	parseFail(JSON.stringify(envelope({
-		brief: briefEnvelope({ learned: [{ lesson: "ok", source: "user@msg-1", evidence: "noise" }] }),
-	})));
-});
-
 test("parseHistoryArtifacts rejects open entries missing fields", () => {
 	parseFail(JSON.stringify(envelope({
 		brief: briefEnvelope({ open: [{ question: "ok" }] }),
@@ -208,28 +248,30 @@ test("parseHistoryArtifacts rejects next entries missing fields", () => {
 	})));
 });
 
-test("parseHistoryArtifacts rejects agentGuideUpdate with wrong keys", () => {
-	parseFail(JSON.stringify(envelope({
-		agentGuideUpdate: { content: null, reason: "ok", extra: true },
-	})));
-	parseFail(JSON.stringify(envelope({
-		agentGuideUpdate: { reason: "missing content" },
-	})));
+test("parseHistoryArtifacts reads an incomplete agentGuideUpdate as no replacement", () => {
+	const noReplacement = (agentGuideUpdate: unknown) => {
+		const payload = envelope({ agentGuideUpdate });
+		if (agentGuideUpdate === undefined) delete (payload as Record<string, unknown>).agentGuideUpdate;
+		const parsed = parseOk(JSON.stringify(payload));
+		assert.equal(parsed.agentGuideMd, undefined);
+		assert.equal(parsed.agentGuideChangeReason, "The handoff model returned no agent guide replacement.");
+	};
+
+	noReplacement(undefined);
+	noReplacement(null);
+	noReplacement({ reason: "" });
+	noReplacement({ content: "   ", reason: null });
 });
 
-test("parseHistoryArtifacts rejects agentGuideUpdate.content empty string", () => {
-	parseFail(JSON.stringify(envelope({
-		agentGuideUpdate: { content: "   ", reason: "empty content rejected" },
+test("parseHistoryArtifacts never schedules an unexplained guide replacement", () => {
+	const parsed = parseOk(JSON.stringify(envelope({
+		agentGuideUpdate: { content: "# AGENTS\n" },
 	})));
-});
-
-test("parseHistoryArtifacts rejects empty agentGuideUpdate.reason", () => {
-	parseFail(JSON.stringify(envelope({
-		agentGuideUpdate: { content: null, reason: "" },
-	})));
-	parseFail(JSON.stringify(envelope({
-		agentGuideUpdate: { content: null, reason: null },
-	})));
+	assert.equal(parsed.agentGuideMd, undefined);
+	assert.equal(
+		parsed.agentGuideChangeReason,
+		"The handoff model returned an agent guide replacement without a reason, so no guide write was scheduled.",
+	);
 });
 
 test("parseHistoryArtifacts collapses multi-line and embedded-bullet field values to single lines", () => {

--- a/tests/details.test.ts
+++ b/tests/details.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildContinuationDetails, buildContinuationSynthesisTelemetry, parseContinuationDetails, renderContinuationDetails } from "../extensions/continue/src/details.ts";
+import { buildContinuationDetails, buildContinuationSynthesisTelemetry, combinePromptPassAttempts, parseContinuationDetails, renderContinuationDetails } from "../extensions/continue/src/details.ts";
 
 const outputBudget = {
 	source: "pi-default" as const,
@@ -49,6 +49,20 @@ test("buildContinuationDetails records current file operations only", () => {
 	assert.equal(details.synthesis?.history?.httpStatus, 200);
 	assert.deepEqual(details.synthesis?.history?.outputBudget, outputBudget);
 	assert.equal(details.synthesis?.totalTokens, 33);
+});
+
+test("combinePromptPassAttempts reports both synthesis attempts", () => {
+	const retry = {
+		...historyTelemetry,
+		responseId: "resp-2",
+		usage: { input: 5, output: 7, cacheRead: 0, cacheWrite: 1, totalTokens: 13, costTotal: 0.002 },
+	};
+
+	assert.deepEqual(combinePromptPassAttempts(undefined, retry), retry);
+	assert.deepEqual(combinePromptPassAttempts(historyTelemetry, retry), {
+		...retry,
+		usage: { input: 15, output: 27, cacheRead: 1, cacheWrite: 3, totalTokens: 46, costTotal: 0.003 },
+	});
 });
 
 test("buildContinuationSynthesisTelemetry stores only allowlisted telemetry", () => {

--- a/tests/docs.test.ts
+++ b/tests/docs.test.ts
@@ -43,7 +43,7 @@ test("README stays a front-facing product and operator guide", () => {
 	assert.match(readme, /When UI is unavailable, use `\/continue` or `\/continue steer\|queue` for direct continuation/);
 	assert.match(readme, /There are no command aliases/);
 	assert.match(readme, /AGENTS\.md sync remain off|[Aa]utomatic AGENTS\.md writes remain off by default/);
-	assert.match(readme, /Requires Pi `0\.74\.0` or newer/);
+	assert.match(readme, /Requires Pi `0\.81\.0` or newer/);
 	assert.doesNotMatch(readme, /unsafe model call/i);
 });
 
@@ -148,10 +148,10 @@ test("package metadata and package contents align with the public contract", () 
 		"examples/",
 		"extensions/",
 	]);
-	assert.equal(packageJson.peerDependencies["@earendil-works/pi-ai"], ">=0.74.0");
-	assert.equal(packageJson.peerDependencies["@earendil-works/pi-coding-agent"], ">=0.74.0");
-	assert.equal(packageJson.peerDependencies["@earendil-works/pi-tui"], ">=0.74.0");
-	assert.equal(packageJson.devDependencies["@earendil-works/pi-tui"], "^0.74.0");
+	assert.equal(packageJson.peerDependencies["@earendil-works/pi-ai"], ">=0.81.0");
+	assert.equal(packageJson.peerDependencies["@earendil-works/pi-coding-agent"], ">=0.81.0");
+	assert.equal(packageJson.peerDependencies["@earendil-works/pi-tui"], ">=0.81.0");
+	assert.equal(packageJson.devDependencies["@earendil-works/pi-tui"], "^0.84.3");
 	assert.deepEqual(packageJson.pi.extensions, ["./extensions/continue/index.ts"]);
 	assert.equal(packageJson.pi.image, "https://raw.githubusercontent.com/Tiziano-AI/pi-continue/v0.9.3/assets/gallery/pi-continue-gallery.webp");
 	assert.equal(existsSync("assets/gallery/pi-continue-gallery.webp"), true);

--- a/tests/index-extension.test.ts
+++ b/tests/index-extension.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, fauxProvider } from "@earendil-works/pi-ai";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -221,15 +221,22 @@ function branchToolResultEntry(id, parentId, toolCallId, text, toolName = "read"
 	});
 }
 
+// Pi can only prepare a native compaction when a turn boundary sits outside the recent
+// keep window, so a compactable branch needs more than the turn Pi would keep whole.
 function compactableToolBranch() {
 	return [
 		branchMessageEntry("branch-user", null, userMessage(`run tool ${"x".repeat(80)}`)),
 		branchAssistantToolEntry("branch-assistant", "branch-user", "tool-1", "/repo/file.ts"),
 		branchToolResultEntry("branch-result", "branch-assistant", "tool-1", "x"),
+		branchMessageEntry("branch-user-2", "branch-result", userMessage(`keep going ${"y".repeat(80)}`)),
+		branchAssistantToolEntry("branch-assistant-2", "branch-user-2", "tool-2", "/repo/other.ts"),
+		branchToolResultEntry("branch-result-2", "branch-assistant-2", "tool-2", "y"),
 	];
 }
 
-function compactionEvent(preparation = {}, branchEntries = []) {
+// Pi always reports what started a compaction. `manual` is what the package's own
+// ctx.compact() request (and a user `/compact`) arrives as.
+function compactionEvent(preparation = {}, branchEntries = [], reason = "manual") {
 	return {
 		preparation: {
 			firstKeptEntryId: "kept-entry",
@@ -244,6 +251,8 @@ function compactionEvent(preparation = {}, branchEntries = []) {
 		},
 		branchEntries,
 		customInstructions: undefined,
+		reason,
+		willRetry: false,
 		signal: new AbortController().signal,
 	};
 }
@@ -357,7 +366,7 @@ test("mid-run guard dispatches resume as follow-up after context threshold proof
 			messages: [userMessage("run tool"), highUsageAssistantMessage(), toolResultMessage("x".repeat(160))],
 		}, ctx);
 		assert.equal(ctx.compactCount, 1);
-		assert.equal(abortCount, 1);
+		assert.equal(abortCount, 0, "ctx.compact() owns the active-run abort");
 		ctx.compactOptions.onComplete({});
 		await pi.events.get("session_compact")(ownedCompactionEvent(), ctx);
 		assert.deepEqual(pi.sent, [CONTINUATION_PROMPT]);
@@ -404,7 +413,7 @@ test("mid-run guard skips cleanly when Pi has no compactable session preparation
 		}), "utf8");
 		await pi.events.get("context")(event, ctx);
 		assert.equal(ctx.compactCount, 1);
-		assert.equal(abortCount, 1);
+		assert.equal(abortCount, 0, "ctx.compact() owns the active-run abort");
 		assert.equal(notifications.length, 2);
 		assert.match(notifications[1][0], /^automatic continuation: saving handoff/);
 		assert.equal(notifications[1][1], "info");
@@ -449,7 +458,7 @@ test("mid-run guard chains when the resumed assistant tool loop fills context ag
 			messages: [userMessage("continue tools"), highUsageAssistantMessage(), toolResultMessage("x".repeat(160))],
 		}, ctx);
 		assert.equal(ctx.compactCount, 2);
-		assert.equal(abortCount, 1);
+		assert.equal(abortCount, 0, "ctx.compact() owns the active-run abort");
 		assert.equal(ctx.workingMessages.at(-1), "pi-continue saving handoff");
 		assert.deepEqual(notifications, [
 			["/continue steer: saving handoff.", "info"],
@@ -831,13 +840,14 @@ test("session_compact ledger display is transient UI and sends only the same-ses
 
 test("session_before_compact and session_compact write default artifact and configured agent guide only after a successful compaction", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-sync-success-"));
-	const faux = registerFauxProvider();
+	const faux = fauxProvider();
 	try {
 		writeAgentGuideSyncConfig(cwd);
 		faux.setResponses([fauxAssistantMessage(continuationArtifactJson("# Agent Guide\n\nDurable rule.\n"))]);
 		const pi = createFakePi(cwd);
 		const ctx = createCommandContext(cwd, async () => undefined);
 		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
 		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
 		registerContinueExtension(pi);
 		await pi.commands.get("continue").handler("steer", ctx);
@@ -867,14 +877,352 @@ test("session_before_compact and session_compact write default artifact and conf
 		assert.match(readFileSync(join(cwd, "AGENTS.md"), "utf8"), /Durable rule/);
 		assert.deepEqual(pi.sent, []);
 	} finally {
-		faux.unregister();
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("a fenced modeled ledger completes the package-owned compaction and resumes", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-fenced-handoff-"));
+	const faux = fauxProvider();
+	try {
+		const fencedArtifact = ["```json", continuationArtifactJson(), "```"].join("\n");
+		faux.setResponses([fauxAssistantMessage(fencedArtifact)]);
+		const pi = createFakePi(cwd);
+		const ctx = createCommandContext(cwd, async () => undefined);
+		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
+		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
+		registerContinueExtension(pi);
+		await pi.commands.get("continue").handler("steer", ctx);
+		const result = await pi.events.get("session_before_compact")(compactionEvent(), ctx);
+		assert.equal(result.compaction.details.continuationEventId, "continue-1");
+		ctx.compactOptions.onComplete({});
+		await pi.events.get("session_compact")({
+			fromExtension: true,
+			compactionEntry: {
+				id: "compact-fenced",
+				summary: result.compaction.summary,
+				details: result.compaction.details,
+			},
+		}, ctx);
+		assert.deepEqual(pi.sent, [CONTINUATION_PROMPT]);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+function overThresholdCompactionEvent(reason = "threshold") {
+	return compactionEvent({
+		tokensBefore: 130,
+		settings: { enabled: true, reserveTokens: 20, keepRecentTokens: 10 },
+	}, [], reason);
+}
+
+// Adoption requires proof that the assistant just finished its own turn, which is
+// what Pi's automatic threshold compaction follows.
+async function completeAssistantTurn(pi, ctx) {
+	await pi.events.get("message_end")({ message: assistantMessage() }, ctx);
+	await pi.events.get("agent_end")({ messages: [] }, ctx);
+}
+
+test("Pi's own over-threshold compaction is adopted as a package handoff", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-adopt-"));
+	const faux = fauxProvider();
+	try {
+		faux.setResponses([fauxAssistantMessage(continuationArtifactJson())]);
+		const pi = createFakePi(cwd);
+		const ctx = createCommandContext(cwd, async () => undefined);
+		ctx.model = { ...faux.models[0], contextWindow: 100 };
+		ctx.modelRegistry.getProvider = () => faux.provider;
+		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
+		registerContinueExtension(pi);
+		await completeAssistantTurn(pi, ctx);
+		const result = await pi.events.get("session_before_compact")(overThresholdCompactionEvent(), ctx);
+		assert.ok("compaction" in result);
+		assert.equal(result.compaction.details.continuationEventId, "continue-1");
+		assert.equal(ctx.compactCount, 0, "Pi already owns the compaction operation");
+		assert.deepEqual(pi.sent, []);
+		await pi.events.get("session_compact")({
+			fromExtension: true,
+			compactionEntry: {
+				id: "compact-adopted",
+				summary: result.compaction.summary,
+				details: result.compaction.details,
+			},
+		}, ctx);
+		assert.deepEqual(pi.sent, [CONTINUATION_PROMPT]);
+		assert.match(readFileSync(continuationArtifactPath(cwd), "utf8"), /## Task\nContinue the task\./);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("below-threshold, manual, and opted-out compactions keep Pi's own summarizer", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-adopt-optout-"));
+	try {
+		const pi = createFakePi(cwd);
+		const ctx = createCommandContext(cwd, async () => undefined);
+		ctx.model = { ...ctx.model, contextWindow: 100 };
+		registerContinueExtension(pi);
+
+		// A /compact request reports its own trigger, with or without a finished turn.
+		assert.equal(await pi.events.get("session_before_compact")(overThresholdCompactionEvent("manual"), ctx), undefined);
+		await completeAssistantTurn(pi, ctx);
+		assert.equal(await pi.events.get("session_before_compact")(overThresholdCompactionEvent("manual"), ctx), undefined);
+
+		// Context-overflow recovery is Pi's to resume.
+		await completeAssistantTurn(pi, ctx);
+		assert.equal(await pi.events.get("session_before_compact")(overThresholdCompactionEvent("overflow"), ctx), undefined);
+
+		// New user input takes the checkpoint away from the finished turn.
+		await completeAssistantTurn(pi, ctx);
+		await pi.events.get("input")({ text: "keep going", source: "interactive" }, ctx);
+		assert.equal(await pi.events.get("session_before_compact")(overThresholdCompactionEvent(), ctx), undefined);
+
+		// Below the threshold there is nothing to own.
+		await completeAssistantTurn(pi, ctx);
+		assert.equal(await pi.events.get("session_before_compact")(compactionEvent({}, [], "threshold"), ctx), undefined);
+
+		mkdirSync(join(cwd, ".pi", "extensions"), { recursive: true });
+		writeFileSync(join(cwd, ".pi", "extensions", "pi-continue.json"), JSON.stringify({
+			adoptNativeCompaction: false,
+		}), "utf8");
+		assert.equal(await pi.events.get("session_before_compact")(overThresholdCompactionEvent(), ctx), undefined);
+		assert.deepEqual(pi.sent, []);
+		assert.equal(existsSync(continuationArtifactPath(cwd)), false);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("a concurrent compaction does not reuse the in-flight handoff owner", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-adopt-concurrent-"));
+	const faux = fauxProvider();
+	try {
+		let releaseFirstAttempt;
+		let synthesisCalls = 0;
+		faux.setResponses([
+			(() => {
+				synthesisCalls += 1;
+				return new Promise((resolve) => {
+					releaseFirstAttempt = () => resolve(fauxAssistantMessage(continuationArtifactJson()));
+				});
+			}),
+			(() => {
+				synthesisCalls += 1;
+				return fauxAssistantMessage(continuationArtifactJson());
+			}),
+		]);
+		const pi = createFakePi(cwd);
+		const ctx = createCommandContext(cwd, async () => undefined);
+		ctx.model = { ...faux.models[0], contextWindow: 100 };
+		ctx.modelRegistry.getProvider = () => faux.provider;
+		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
+		registerContinueExtension(pi);
+		await completeAssistantTurn(pi, ctx);
+
+		const inFlight = pi.events.get("session_before_compact")(overThresholdCompactionEvent(), ctx);
+		assert.deepEqual(
+			await pi.events.get("session_before_compact")(overThresholdCompactionEvent(), ctx),
+			{ cancel: true },
+			"a concurrent compaction is cancelled instead of summarizing the same branch in parallel",
+		);
+		for (let waits = 0; !releaseFirstAttempt && waits < 200; waits += 1) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+		assert.ok(releaseFirstAttempt, "the first compaction reached ledger synthesis");
+		releaseFirstAttempt();
+		const result = await inFlight;
+
+		assert.ok("compaction" in result);
+		assert.equal(result.compaction.details.continuationEventId, "continue-1");
+		assert.equal(synthesisCalls, 1, "the concurrent compaction does not run a second synthesis");
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+// Pi's own ctx.compact() aborts the active run, and Pi reads that aborted turn as an
+// error response that is over the threshold, so it starts an automatic compaction of the
+// same branch while the package-owned request is still waiting for Pi to go idle.
+function abortedRunAssistantMessage() {
+	return { ...assistantMessage("error"), content: [], errorMessage: "This operation was aborted" };
+}
+
+function savedCompactionEvent(compaction, id = "compact-owned") {
+	return {
+		fromExtension: true,
+		compactionEntry: { id, summary: compaction.summary, details: compaction.details },
+	};
+}
+
+test("Pi's own compaction cannot race the package-owned handoff request", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-owned-race-"));
+	const faux = fauxProvider();
+	try {
+		faux.setResponses([fauxAssistantMessage(continuationArtifactJson())]);
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		writeFileSync(join(cwd, ".pi", "settings.json"), JSON.stringify({
+			compaction: { enabled: true, reserveTokens: 20, keepRecentTokens: 10 },
+		}), "utf8");
+		const pi = createFakePi(cwd);
+		const ctx = createCommandContext(cwd, async () => undefined);
+		ctx.model = { ...faux.models[0], contextWindow: 100 };
+		ctx.modelRegistry.getProvider = () => faux.provider;
+		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
+		ctx.setBranch(compactableToolBranch());
+		registerContinueExtension(pi);
+		await pi.events.get("context")({
+			messages: [userMessage("run tool"), highUsageAssistantMessage(), toolResultMessage("x".repeat(160))],
+		}, ctx);
+		assert.equal(ctx.compactCount, 1);
+
+		// Pi's aborted-run compaction arrives before Pi runs the package-owned request.
+		await pi.events.get("message_end")({ message: abortedRunAssistantMessage() }, ctx);
+		await pi.events.get("agent_end")({ messages: [] }, ctx);
+		assert.deepEqual(
+			await pi.events.get("session_before_compact")(overThresholdCompactionEvent("threshold"), ctx),
+			{ cancel: true },
+			"the package-owned request stays the single owner of the branch",
+		);
+
+		const result = await pi.events.get("session_before_compact")(overThresholdCompactionEvent("manual"), ctx);
+		assert.ok("compaction" in result, "the package-owned request still saves its own handoff");
+		assert.equal(result.compaction.details.continuationEventId, "continue-1");
+		ctx.compactOptions.onComplete({});
+		await pi.events.get("session_compact")(savedCompactionEvent(result.compaction), ctx);
+		assert.deepEqual(pi.sent, [CONTINUATION_PROMPT]);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("a handoff another compaction already saved resumes instead of failing", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-owned-saved-elsewhere-"));
+	const faux = fauxProvider();
+	try {
+		faux.setResponses([fauxAssistantMessage(continuationArtifactJson())]);
+		mkdirSync(join(cwd, ".pi", "extensions"), { recursive: true });
+		writeFileSync(join(cwd, ".pi", "extensions", "pi-continue.json"), JSON.stringify({
+			continuationArtifactMode: "off",
+			showAfterCompact: false,
+		}), "utf8");
+		const pi = createFakePi(cwd);
+		const notifications = [];
+		const ctx = createCommandContext(cwd, async () => undefined);
+		ctx.model = { ...faux.models[0], contextWindow: 100 };
+		ctx.modelRegistry.getProvider = () => faux.provider;
+		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
+		ctx.ui.notify = (message, type) => {
+			notifications.push([message, type]);
+		};
+		registerContinueExtension(pi);
+		await pi.commands.get("continue").handler("steer", ctx);
+		assert.equal(ctx.compactCount, 1);
+
+		// A `/compact` request is not Pi's own automatic compaction, so it is not cancelled;
+		// it saves the package-owned handoff of the active event before Pi runs that request.
+		const result = await pi.events.get("session_before_compact")(overThresholdCompactionEvent("manual"), ctx);
+		assert.ok("compaction" in result);
+		assert.equal(result.compaction.details.continuationEventId, "continue-1");
+		await pi.events.get("session_compact")(savedCompactionEvent(result.compaction), ctx);
+		assert.deepEqual(pi.sent, [], "resume waits until the package-owned request settles");
+
+		ctx.compactOptions.onError(new Error("Already compacted"));
+		assert.deepEqual(pi.sent, [CONTINUATION_PROMPT], "the saved handoff proof still resumes the session");
+		assert.deepEqual(notifications, [
+			["/continue steer: saving handoff.", "info"],
+			["/continue steer: another compaction already saved this handoff.", "warning"],
+			["/continue steer: resume request sent.", "info"],
+		]);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("an adopted compaction without a usable handoff is handed back to Pi", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-adopt-release-"));
+	const faux = fauxProvider();
+	try {
+		faux.setResponses([fauxAssistantMessage("not json"), fauxAssistantMessage("still not json")]);
+		const pi = createFakePi(cwd);
+		const ctx = createCommandContext(cwd, async () => undefined);
+		ctx.model = { ...faux.models[0], contextWindow: 100 };
+		ctx.modelRegistry.getProvider = () => faux.provider;
+		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
+		registerContinueExtension(pi);
+		await completeAssistantTurn(pi, ctx);
+		assert.equal(await pi.events.get("session_before_compact")(overThresholdCompactionEvent(), ctx), undefined);
+		assertNoFailedSynthesisSideEffects(cwd, pi);
+
+		// A released checkpoint is spent; the next adoption needs the next finished turn.
+		assert.equal(await pi.events.get("session_before_compact")(overThresholdCompactionEvent(), ctx), undefined);
+
+		faux.setResponses([fauxAssistantMessage(continuationArtifactJson())]);
+		await completeAssistantTurn(pi, ctx);
+		const recovered = await pi.events.get("session_before_compact")(overThresholdCompactionEvent(), ctx);
+		assert.ok("compaction" in recovered, "a released checkpoint does not block the next adoption");
+		assert.equal(recovered.compaction.details.continuationEventId, "continue-2");
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("a reminded second synthesis attempt recovers a handoff from a non-compliant first response", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-artifact-retry-"));
+	const faux = fauxProvider({ models: [{ id: "faux-reasoning", reasoning: true }] });
+	try {
+		const prompts = [];
+		const reasoningLevels = [];
+		const recordAttempt = (context, options) => {
+			prompts.push(JSON.stringify(context));
+			reasoningLevels.push(options?.reasoning);
+		};
+		faux.setResponses([
+			((context, options) => {
+				recordAttempt(context, options);
+				return fauxAssistantMessage("I cannot produce that handoff as JSON right now.");
+			}),
+			((context, options) => {
+				recordAttempt(context, options);
+				return fauxAssistantMessage(continuationArtifactJson());
+			}),
+		]);
+		const pi = createFakePi(cwd);
+		pi.getThinkingLevel = () => "high";
+		const ctx = createCommandContext(cwd, async () => undefined);
+		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
+		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
+		registerContinueExtension(pi);
+		await pi.commands.get("continue").handler("steer", ctx);
+		const result = await pi.events.get("session_before_compact")(compactionEvent(), ctx);
+		assert.ok("compaction" in result);
+		assert.equal(prompts.length, 2);
+		assert.doesNotMatch(prompts[0], /artifact-format-retry/);
+		assert.match(prompts[1], /artifact-format-retry/);
+		assert.deepEqual(reasoningLevels, ["high", undefined], "the retry frees the output budget from reasoning tokens");
+		const usage = result.compaction.details.synthesis.history.usage;
+		assert.equal(result.compaction.details.synthesis.totalTokens, usage.totalTokens);
+		assert.ok(usage.output > 0, "both synthesis attempts are reported");
+		ctx.compactOptions.onComplete({});
+		await pi.events.get("session_compact")({
+			fromExtension: true,
+			compactionEntry: {
+				id: "compact-retry",
+				summary: result.compaction.summary,
+				details: result.compaction.details,
+			},
+		}, ctx);
+		assert.deepEqual(pi.sent, [CONTINUATION_PROMPT]);
+	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 	}
 });
 
 test("session_before_compact summarizes provider-unsafe kept suffixes before returning compaction proof", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-provider-safe-"));
-	const faux = registerFauxProvider();
+	const faux = fauxProvider();
 	try {
 		let observedPrompt = "";
 		faux.setResponses([((context) => {
@@ -884,6 +1232,7 @@ test("session_before_compact summarizes provider-unsafe kept suffixes before ret
 		const pi = createFakePi(cwd);
 		const ctx = createCommandContext(cwd, async () => undefined);
 		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
 		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
 		registerContinueExtension(pi);
 		await pi.commands.get("continue").handler("steer", ctx);
@@ -907,14 +1256,13 @@ test("session_before_compact summarizes provider-unsafe kept suffixes before ret
 		assert.match(observedPrompt, /late child output/);
 		assert.deepEqual(pi.sent, []);
 	} finally {
-		faux.unregister();
 		rmSync(cwd, { recursive: true, force: true });
 	}
 });
 
 test("session_before_compact omits stale continuation docs and prior artifacts from provider prompt", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-no-stale-input-"));
-	const faux = registerFauxProvider();
+	const faux = fauxProvider();
 	try {
 		writeFileSync(join(cwd, "CONTINUE.md"), "STALE_CONTINUE_SENTINEL", "utf8");
 		mkdirSync(join(cwd, ".pi", "continue"), { recursive: true });
@@ -927,6 +1275,7 @@ test("session_before_compact omits stale continuation docs and prior artifacts f
 		const pi = createFakePi(cwd);
 		const ctx = createCommandContext(cwd, async () => undefined);
 		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
 		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
 		registerContinueExtension(pi);
 		await pi.commands.get("continue").handler("steer", ctx);
@@ -937,7 +1286,6 @@ test("session_before_compact omits stale continuation docs and prior artifacts f
 		assert.doesNotMatch(observedPrompt, /existing-continuation-md/);
 		assert.doesNotMatch(observedPrompt, /continuation-doc-path/);
 	} finally {
-		faux.unregister();
 		rmSync(cwd, { recursive: true, force: true });
 	}
 });
@@ -945,13 +1293,14 @@ test("session_before_compact omits stale continuation docs and prior artifacts f
 
 test("continuationArtifactMode off suppresses successful artifact writes", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-artifact-off-"));
-	const faux = registerFauxProvider();
+	const faux = fauxProvider();
 	try {
 		writeArtifactOffConfig(cwd);
 		faux.setResponses([fauxAssistantMessage(continuationArtifactJson())]);
 		const pi = createFakePi(cwd);
 		const ctx = createCommandContext(cwd, async () => undefined);
 		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
 		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
 		registerContinueExtension(pi);
 		await pi.commands.get("continue").handler("steer", ctx);
@@ -968,7 +1317,6 @@ test("continuationArtifactMode off suppresses successful artifact writes", async
 		assert.equal(existsSync(continuationArtifactPath(cwd)), false);
 		assert.equal(existsSync(join(cwd, "CONTINUE.md")), false);
 	} finally {
-		faux.unregister();
 		rmSync(cwd, { recursive: true, force: true });
 	}
 });
@@ -976,7 +1324,7 @@ test("continuationArtifactMode off suppresses successful artifact writes", async
 
 test("session_before_compact clamps history output budget to model max tokens", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-output-clamp-"));
-	const faux = registerFauxProvider({ models: [{ id: "small-output", reasoning: false, maxTokens: 256 }] });
+	const faux = fauxProvider({ models: [{ id: "small-output", reasoning: false, maxTokens: 256 }] });
 	try {
 		let observedMaxTokens;
 		faux.setResponses([(_context, options) => {
@@ -986,6 +1334,7 @@ test("session_before_compact clamps history output budget to model max tokens", 
 		const pi = createFakePi(cwd);
 		const ctx = createCommandContext(cwd, async () => undefined);
 		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
 		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
 		registerContinueExtension(pi);
 		await pi.commands.get("continue").handler("steer", ctx);
@@ -998,14 +1347,13 @@ test("session_before_compact clamps history output budget to model max tokens", 
 		assert.equal(result.compaction.details.synthesis.history.outputBudget.effectiveTokens, 256);
 		assert.equal(result.compaction.details.synthesis.history.outputBudget.clampedByModel, true);
 	} finally {
-		faux.unregister();
 		rmSync(cwd, { recursive: true, force: true });
 	}
 });
 
 test("session_before_compact cancels instead of returning ownerless details when ownership is lost during synthesis", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-owner-lost-"));
-	const faux = registerFauxProvider();
+	const faux = fauxProvider();
 	try {
 		let releaseResponse = () => {};
 		const providerStarted = new Promise((resolveStarted) => {
@@ -1020,6 +1368,7 @@ test("session_before_compact cancels instead of returning ownerless details when
 		const pi = createFakePi(cwd);
 		const ctx = createCommandContext(cwd, async () => undefined);
 		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
 		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
 		registerContinueExtension(pi);
 		await pi.commands.get("continue").handler("steer", ctx);
@@ -1031,14 +1380,13 @@ test("session_before_compact cancels instead of returning ownerless details when
 		assert.deepEqual(result, { cancel: true });
 		assertNoFailedSynthesisSideEffects(cwd, pi);
 	} finally {
-		faux.unregister();
 		rmSync(cwd, { recursive: true, force: true });
 	}
 });
 
 test("session_before_compact does not attribute an old synthesis to a newer continuation owner", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-owner-replaced-"));
-	const faux = registerFauxProvider();
+	const faux = fauxProvider();
 	try {
 		let releaseResponse = () => {};
 		const providerStarted = new Promise((resolveStarted) => {
@@ -1053,6 +1401,7 @@ test("session_before_compact does not attribute an old synthesis to a newer cont
 		const pi = createFakePi(cwd);
 		const ctx = createCommandContext(cwd, async () => undefined);
 		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
 		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
 		registerContinueExtension(pi);
 		await pi.commands.get("continue").handler("steer", ctx);
@@ -1069,20 +1418,20 @@ test("session_before_compact does not attribute an old synthesis to a newer cont
 		await pi.commands.get("continue").handler("steer", ctx);
 		assert.equal(ctx.compactCount, compactCountBeforeRetry);
 	} finally {
-		faux.unregister();
 		rmSync(cwd, { recursive: true, force: true });
 	}
 });
 
 test("late compaction for abandoned owner does not fail a newer active handoff", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-late-abandoned-owner-"));
-	const faux = registerFauxProvider();
+	const faux = fauxProvider();
 	try {
 		writeAgentGuideSyncConfig(cwd);
 		faux.setResponses([fauxAssistantMessage(continuationArtifactJson("# Agent Guide\n\nOld abandoned guide.\n"))]);
 		const pi = createFakePi(cwd);
 		const ctx = createCommandContext(cwd, async () => undefined);
 		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
 		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
 		registerContinueExtension(pi);
 		await pi.commands.get("continue").handler("steer", ctx);
@@ -1105,7 +1454,6 @@ test("late compaction for abandoned owner does not fail a newer active handoff",
 		await pi.events.get("session_compact")(ownedCompactionEvent("continue-2"), ctx);
 		assert.deepEqual(pi.sent, [CONTINUATION_PROMPT]);
 	} finally {
-		faux.unregister();
 		rmSync(cwd, { recursive: true, force: true });
 	}
 });
@@ -1132,7 +1480,7 @@ test("session_before_compact fails closed when ledger synthesis cannot authentic
 
 test("session_before_compact fails closed when ledger synthesis times out", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-timeout-hard-fail-"));
-	const faux = registerFauxProvider();
+	const faux = fauxProvider();
 	try {
 		mkdirSync(join(cwd, ".pi", "extensions"), { recursive: true });
 		writeFileSync(join(cwd, ".pi", "extensions", "pi-continue.json"), JSON.stringify({
@@ -1150,6 +1498,7 @@ test("session_before_compact fails closed when ledger synthesis times out", asyn
 		const pi = createFakePi(cwd);
 		const ctx = createCommandContext(cwd, async () => undefined);
 		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
 		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
 		registerContinueExtension(pi);
 		await pi.commands.get("continue").handler("steer", ctx);
@@ -1159,20 +1508,50 @@ test("session_before_compact fails closed when ledger synthesis times out", asyn
 		assert.ok(Date.now() - startedAt < 1000);
 		assertNoFailedSynthesisSideEffects(cwd, pi);
 	} finally {
-		faux.unregister();
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("a truncated handoff response reports the output-limit cause when it fails closed", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-truncated-"));
+	const faux = fauxProvider();
+	try {
+		const truncated = () => fauxAssistantMessage(continuationArtifactJson().slice(0, 120), { stopReason: "length" });
+		faux.setResponses([truncated(), truncated()]);
+		const notifications = [];
+		const pi = createFakePi(cwd);
+		const ctx = createCommandContext(cwd, async () => undefined);
+		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
+		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
+		ctx.ui.notify = (message, type) => {
+			notifications.push([message, type]);
+		};
+		registerContinueExtension(pi);
+		await pi.commands.get("continue").handler("steer", ctx);
+		const result = await pi.events.get("session_before_compact")(compactionEvent(), ctx);
+		assert.deepEqual(result, { cancel: true });
+		ctx.compactOptions.onError(new Error("Compaction cancelled"));
+		assert.match(
+			notifications.at(-1)[0],
+			/handoff failed: pi-continue could not create a usable handoff, so continuation stopped before resuming\. Cause: response stopped at the output token limit/,
+		);
+		assertNoFailedSynthesisSideEffects(cwd, pi);
+	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 	}
 });
 
 test("session_before_compact fails closed when history artifacts are malformed", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-hard-fail-"));
-	const faux = registerFauxProvider();
+	const faux = fauxProvider();
 	try {
 		writeAgentGuideSyncConfig(cwd);
 		faux.setResponses([fauxAssistantMessage("not json")]);
 		const pi = createFakePi(cwd);
 		const ctx = createCommandContext(cwd, async () => undefined);
 		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
 		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
 		registerContinueExtension(pi);
 		await pi.commands.get("continue").handler("steer", ctx);
@@ -1180,7 +1559,6 @@ test("session_before_compact fails closed when history artifacts are malformed",
 		assert.deepEqual(result, { cancel: true });
 		assertNoFailedSynthesisSideEffects(cwd, pi);
 	} finally {
-		faux.unregister();
 		rmSync(cwd, { recursive: true, force: true });
 	}
 });
@@ -1222,7 +1600,7 @@ test("session_before_compact opts out when no extension-owned continuation event
 
 test("session_before_compact rejects wrong current artifact shape from the synthesizer", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-continue-shape-reject-"));
-	const faux = registerFauxProvider();
+	const faux = fauxProvider();
 	try {
 		writeAgentGuideSyncConfig(cwd);
 		const wrongEnvelope = JSON.stringify({
@@ -1234,6 +1612,7 @@ test("session_before_compact rejects wrong current artifact shape from the synth
 		const pi = createFakePi(cwd);
 		const ctx = createCommandContext(cwd, async () => undefined);
 		ctx.model = faux.models[0];
+		ctx.modelRegistry.getProvider = () => faux.provider;
 		ctx.modelRegistry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "test", headers: {} });
 		registerContinueExtension(pi);
 		await pi.commands.get("continue").handler("steer", ctx);
@@ -1241,7 +1620,6 @@ test("session_before_compact rejects wrong current artifact shape from the synth
 		assert.deepEqual(result, { cancel: true });
 		assertNoFailedSynthesisSideEffects(cwd, pi);
 	} finally {
-		faux.unregister();
 		rmSync(cwd, { recursive: true, force: true });
 	}
 });

--- a/tests/mid-run-guard.test.ts
+++ b/tests/mid-run-guard.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { DEFAULT_CONTINUE_CONFIG } from "../extensions/continue/src/config.ts";
 import {
+	ADOPTION_CHECKPOINT_MAX_AGE_MS,
+	decideAdoptedCompactionTrigger,
 	decideMidRunGuardTrigger,
 	hasNativeCompactionPreparation,
 	shouldEvaluateMidRunContext,
@@ -125,6 +128,73 @@ test("decideMidRunGuardTrigger only trips above the reserve threshold", () => {
 		trailingTokens: 11,
 		lastUsageIndex: 3,
 	});
+});
+
+test("decideAdoptedCompactionTrigger owns only over-threshold Pi compactions", () => {
+	const now = 10_000;
+	const base = {
+		config: DEFAULT_CONTINUE_CONFIG,
+		piCompactionEnabled: true,
+		contextWindow: 100,
+		reserveTokens: 20,
+		tokensBefore: 130,
+		checkpoint: { stopReason: "stop", openedAt: now - 10 },
+		reason: "threshold",
+		now,
+	};
+
+	assert.deepEqual(decideAdoptedCompactionTrigger(base), {
+		estimatedTokens: 130,
+		thresholdTokens: 80,
+		contextWindow: 100,
+		reserveTokens: 20,
+		usageTokens: 130,
+		trailingTokens: 0,
+		lastUsageIndex: null,
+	});
+	assert.equal(decideAdoptedCompactionTrigger({ ...base, tokensBefore: 80 }), undefined);
+	assert.equal(decideAdoptedCompactionTrigger({ ...base, contextWindow: undefined }), undefined);
+	assert.equal(decideAdoptedCompactionTrigger({ ...base, reserveTokens: 100 }), undefined);
+	assert.equal(decideAdoptedCompactionTrigger({ ...base, piCompactionEnabled: false }), undefined);
+	assert.equal(decideAdoptedCompactionTrigger({
+		...base,
+		config: { ...DEFAULT_CONTINUE_CONFIG, adoptNativeCompaction: false },
+	}), undefined);
+	assert.equal(decideAdoptedCompactionTrigger({
+		...base,
+		config: { ...DEFAULT_CONTINUE_CONFIG, enabled: false },
+	}), undefined);
+});
+
+test("decideAdoptedCompactionTrigger requires the checkpoint of a finished assistant turn", () => {
+	const now = 10_000;
+	const adoptable = {
+		config: DEFAULT_CONTINUE_CONFIG,
+		piCompactionEnabled: true,
+		contextWindow: 100,
+		reserveTokens: 20,
+		tokensBefore: 130,
+		checkpoint: { stopReason: "stop", openedAt: now - 10 },
+		reason: "threshold",
+		now,
+	};
+	const checkpoint = (overrides: Record<string, unknown> | undefined) => decideAdoptedCompactionTrigger({
+		...adoptable,
+		checkpoint: overrides === undefined ? undefined : { ...adoptable.checkpoint, ...overrides },
+	});
+
+	assert.ok(decideAdoptedCompactionTrigger(adoptable), "a claimed fresh checkpoint is adoptable");
+	// Manual /compact, a compaction while input is submitted, and a second compaction for the
+	// same turn all arrive without an open checkpoint.
+	assert.equal(checkpoint(undefined), undefined);
+	assert.equal(checkpoint({ openedAt: now - ADOPTION_CHECKPOINT_MAX_AGE_MS - 1 }), undefined);
+	// Context-overflow recovery and cancelled turns are Pi's to resume, not the package's.
+	assert.equal(checkpoint({ stopReason: "error" }), undefined);
+	assert.equal(checkpoint({ stopReason: "aborted" }), undefined);
+	assert.equal(checkpoint({ stopReason: undefined }), undefined);
+	// Pi reports a /compact request and context-overflow recovery as their own triggers.
+	assert.equal(decideAdoptedCompactionTrigger({ ...adoptable, reason: "manual" }), undefined);
+	assert.equal(decideAdoptedCompactionTrigger({ ...adoptable, reason: "overflow" }), undefined);
 });
 
 test("hasNativeCompactionPreparation rejects Pi's false no-preparation sentinel", () => {

--- a/tests/runtime-resume-proof.test.ts
+++ b/tests/runtime-resume-proof.test.ts
@@ -65,7 +65,7 @@ test("startContinuationCompaction sends resume only after owned compaction proof
 		sendContinuation: (prompt) => continuations.push(prompt),
 	});
 	assert.equal(started, true);
-	assert.equal(owner.aborts, 1);
+	assert.equal(owner.aborts, 0, "ctx.compact() owns the active-run abort");
 	assert.equal(runtime.compactionRunning, true);
 	assert.equal(runtime.latestEvent?.source, "command-steer");
 	assert.equal(runtime.latestEvent?.status, "running");
@@ -96,6 +96,30 @@ test("startContinuationCompaction sends resume only after owned compaction proof
 	assert.equal(runtime.latestEvent?.status, "completed");
 	assert.equal(runtime.latestEvent?.resume.status, "completed");
 	assert.equal(runtime.activeEventId, undefined);
+});
+
+test("continuation lets ctx.compact perform the only active-run abort", () => {
+	const owner = createContext(false);
+	const ctx = bindContext(owner);
+	const compact = ctx.compact;
+	ctx.compact = (options) => {
+		owner.aborts += 1;
+		compact.call(ctx, options);
+	};
+	const runtime = createContinuationRuntimeState();
+
+	const started = startContinuationCompaction(ctx, runtime, {
+		source: "mid-run-guard",
+		instructions: undefined,
+		trigger: undefined,
+		abortActiveRun: true,
+		continueAfterComplete: true,
+		sendContinuation: () => {},
+	});
+
+	assert.equal(started, true);
+	assert.equal(owner.aborts, 1);
+	assert.equal(runtime.compactionRunning, true);
 });
 
 test("synchronous resume start proof survives verified dispatch ordering", () => {

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -9,8 +9,10 @@ import {
 	failRunningAwaitingContinuationResume,
 	markAwaitingContinuationResumeStarted,
 	parseContinuationRequest,
+	releaseAdoptedContinuationCompaction,
 	runContinuationCommand,
 	settleAwaitingContinuationResumeFromAssistant,
+	startAdoptedContinuationCompaction,
 	startContinuationCompaction,
 } from "../extensions/continue/src/runtime.ts";
 
@@ -215,7 +217,7 @@ test("mid-run guard can chain after a resumed assistant tool-use turn", () => {
 		sendContinuation: (prompt) => continuations.push(prompt),
 	});
 	assert.equal(guard, true);
-	assert.equal(owner.aborts, 1);
+	assert.equal(owner.aborts, 0, "ctx.compact() owns the active-run abort");
 	assert.equal(runtime.latestEvent?.id, "continue-2");
 	assert.equal(runtime.latestEvent?.status, "running");
 	assert.equal(runtime.latestEvent?.resume.status, "not-requested");
@@ -486,7 +488,7 @@ test("failed guard records a failure key and blocks identical retries", () => {
 		sendContinuation: (prompt) => continuations.push(prompt),
 	});
 	assert.equal(retry, false);
-	assert.equal(owner.aborts, 2);
+	assert.equal(owner.aborts, 1, "only the blocked retry aborts the over-limit run");
 	assert.equal(runtime.latestEvent?.status, "blocked");
 	assert.equal(runtime.latestEvent?.failureReason, "Repeated over-limit retry was blocked after a failed continuation.");
 });
@@ -552,6 +554,37 @@ test("compaction failures call the pending-write cleanup hook", () => {
 	assert.equal(started, true);
 	owner.compactOptions.onError(new Error("permission denied"));
 	assert.deepEqual(failedEvents, ["continue-1"]);
+});
+
+test("releasing a settled adopted compaction leaves a newer continuation untouched", () => {
+	const releaseOwner = createContext(true);
+	const releaseCtx = bindContext(releaseOwner);
+	const runtime = createContinuationRuntimeState();
+	const releasedEvents = [];
+
+	const staleEventId = startAdoptedContinuationCompaction(releaseCtx, runtime, {
+		trigger,
+		continueAfterComplete: true,
+		sendContinuation: () => {},
+	});
+	assert.equal(staleEventId, "continue-1");
+	// The adopted owner is settled while its synthesis is still running.
+	releaseAdoptedContinuationCompaction(releaseCtx, runtime, staleEventId, (eventId) => releasedEvents.push(eventId));
+	assert.deepEqual(releasedEvents, ["continue-1"]);
+
+	const freshEventId = startAdoptedContinuationCompaction(releaseCtx, runtime, {
+		trigger,
+		continueAfterComplete: true,
+		sendContinuation: () => {},
+	});
+	assert.equal(freshEventId, "continue-2");
+
+	// A late release from the stale handler must not clear the newer owner's state.
+	releaseAdoptedContinuationCompaction(releaseCtx, runtime, staleEventId, (eventId) => releasedEvents.push(eventId));
+	assert.deepEqual(releasedEvents, ["continue-1"]);
+	assert.equal(runtime.activeEventId, "continue-2");
+	assert.equal(runtime.latestEvent?.status, "running");
+	assert.equal(runtime.pendingResumeDispatch?.eventId, "continue-2");
 });
 
 test("runContinuationCommand queue waits for idle before compaction", async () => {


### PR DESCRIPTION
## Summary
- Own Pi's over-threshold compaction after a finished assistant turn (`adoptNativeCompaction`, default on), so end-of-turn automatic compaction also saves a Continuation Ledger and resumes the same session instead of falling back to Pi's summarizer.
- Keep instructed `/compact`, compaction while new user input is submitted, cancelled turns, and context-overflow recovery on Pi's summarizer; cancel a concurrent compaction instead of summarizing the same branch twice; hand an adopted checkpoint back to Pi when its ledger cannot be built.
- Read a complete ledger through model presentation wrappers (fences, reasoning tags, prose) while failing closed on competing artifacts.
- Retry synthesis once with a format reminder and reasoning disabled, classify responses truncated at the output token limit, and report the bounded failure cause with the failure message.
- Let `ctx.compact()` own active-run cancellation so a competing auto-compaction cannot fail the handoff with `Already compacted`.

### Why

In a Codex session that hit the threshold six times, only the first two compactions were `pi-continue/v4`; the rest were native Pi compactions with no ledger and no resume, because `session_before_compact` opted out whenever `pi-continue` had not started the compaction itself.

Fixes #11

## Testing
- `pnpm run gate` (239 tests)